### PR TITLE
Complete v16.0.0: Hermes Agent support + multi-platform rebrand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [16.0.0] — Multi-Platform — 2026-06-17
+
+The library stops being Claude-only and becomes a portable, single-source-of-truth project.
+
 ### Added
+- **Hermes Agent support (native).** `scripts/sync-hermes-skills.py` installs the
+  canonical `skills/` into `~/.hermes/skills/` (copy or `--link` symlink). Hermes reads
+  the same open `SKILL.md` standard, so there is no format conversion — it auto-discovers
+  skills by their `description`, exactly like Claude Code.
 - **Multi-platform export generator.** `scripts/build-exports.mjs` renders every skill
   into platform-ready files under `exports/` from a single source of truth (the
   `SKILL.md` body), so content is never maintained twice. Ships **ChatGPT**
@@ -32,21 +42,37 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
   **Production-Ready**, **Stable**, or **Experimental** so new users start with the
   strongest work.
 - **Cross-tool compatibility** — README now documents which platforms the skills work
-  on (Claude Code natively; the SKILL.md bodies port to other agents and chat LLMs).
+  on (Claude Code and Hermes natively; the SKILL.md bodies port to other agents and chat LLMs).
 - **Skill Playground upgrades** — the hosted web app gains a **tier filter** and per-tile
   tier badges, plus a *"Use this skill in another tool"* panel that copies the
   instructions formatted for ChatGPT, Gemini, or raw. Tier data comes from a single
   machine-readable source, `skill-tiers.json`.
+- **Related Projects** — README section linking to other community Claude Skills
+  libraries and the `awesome-claude-skills` / `awesome-claude-code` lists.
+
+### Changed
+- **Multi-platform rebrand.** README title, tagline, intro, and badges now position the
+  library for Claude, ChatGPT, Gemini, and Hermes — not Claude alone. (The repository
+  name, marketplace ID, and install commands are unchanged.)
+- `SECURITY.md` supported-versions table updated to the v16 release line.
 
 ### Fixed
 - **`web/skills.json` is now deterministic.** Removed the wall-clock `generatedAt` field
   (it was unused by the UI and made every rebuild differ), so the new `check-generated`
   CI step can reliably verify the index is in sync with the source skills.
-- **Related Projects** — README section linking to other community Claude Skills
-  libraries and the `awesome-claude-skills` / `awesome-claude-code` lists.
 
-### Changed
-- `SECURITY.md` supported-versions table updated to the current release line.
+## [15.0.0] — Skill Playground — 2026-06-09
+
+### Added
+- **Skill Playground** — a zero-backend browser app (`web/`) to run any skill with your own
+  Claude API key. Tile gallery with search + bundle filter, click-to-run forms generated from
+  each skill's `Required Inputs`, live streaming output with copy / download-as-`.md`, and a
+  model picker. `web/build-skills.mjs` generates `skills.json`; a GitHub Actions workflow
+  auto-deploys to GitHub Pages on every push to `main`.
+
+### Fixed
+- Mid-stream API errors now surface to the user instead of being silently swallowed.
+- `max_tokens` raised to 8192 to avoid truncating long outputs.
 
 ## [14.0.0] — Writers & Content Creators + 7 Community Skills
 
@@ -105,5 +131,7 @@ Earlier releases (v1.0.0 – v5.0.0) predate this changelog. See the
 [article series](README.md#-the-article-series) for the full history of how the
 library grew from the first PM toolkit to 100+ skills.
 
-[Unreleased]: https://github.com/mohitagw15856/pm-claude-skills/compare/v14.0.0...HEAD
+[Unreleased]: https://github.com/mohitagw15856/pm-claude-skills/compare/v16.0.0...HEAD
+[16.0.0]: https://github.com/mohitagw15856/pm-claude-skills/compare/v15.0.0...v16.0.0
+[15.0.0]: https://github.com/mohitagw15856/pm-claude-skills/compare/v14.0.0...v15.0.0
 [14.0.0]: https://github.com/mohitagw15856/pm-claude-skills/releases

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
-# 🧠 PM Claude Skills — 167 Skills for Every Profession
+# 🧠 PM Skills — 167 Professional Skills for Claude, ChatGPT, Gemini & Hermes
 
 [![Stars](https://img.shields.io/github/stars/mohitagw15856/pm-claude-skills?style=social)](https://github.com/mohitagw15856/pm-claude-skills/stargazers)
 [![Skills](https://img.shields.io/badge/skills-167-blue)](https://github.com/mohitagw15856/pm-claude-skills)
-[![Version](https://img.shields.io/badge/version-14.0.0-brightgreen)](https://github.com/mohitagw15856/pm-claude-skills/releases)
+[![Platforms](https://img.shields.io/badge/works%20with-Claude%20%7C%20ChatGPT%20%7C%20Gemini%20%7C%20Hermes-8A2BE2)](#-works-with--cross-tool-compatibility)
+[![Version](https://img.shields.io/badge/version-16.0.0-brightgreen)](https://github.com/mohitagw15856/pm-claude-skills/releases)
 [![Install](https://img.shields.io/badge/Install%20in%20Claude%20Code-2%20minutes-orange)](https://github.com/mohitagw15856/pm-claude-skills#-quick-install-2-minutes)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/sponsor-❤️-ff69b4)](https://github.com/sponsors/mohitagw15856)
 
 > **PM stands for Professional, not just Product Management.**
-> 167 Claude Skills + 4 agent templates across 26 bundles covering 18 professions. Built by a PM, used by everyone.
+> 167 professional skills + 4 agent templates across 26 bundles covering 18 professions. Built for Claude Code — and now portable to ChatGPT, Gemini, and Hermes Agent. Built by a PM, used by everyone.
 
-A community-built library of Claude Skills for professionals across every field — product management, engineering, customer success, marketing, social media, writers, design, legal, finance, HR, sales, operations, research, and more. Each skill is a structured SKILL.md file that teaches Claude how to produce professional-grade outputs for your specific workflows.
+A community-built library of professional skills for every field — product management, engineering, customer success, marketing, social media, writers, design, legal, finance, HR, sales, operations, research, and more. Each skill is a structured `SKILL.md` file that teaches an AI assistant how to produce professional-grade outputs for your workflows. Skills run natively in **Claude Code** and **Hermes Agent** (same open `SKILL.md` standard), and ship as ready-to-paste exports for **ChatGPT** and **Gemini** — see [Works With](#-works-with--cross-tool-compatibility).
 
-**🆕 Latest release (v14.0.0):** 12 new community-inspired skills across 4 bundles — a brand new Writers & Content Creators profession (Instagram downloader, AEO optimizer, thumbnail creator, Substack scraper, notes humanizer), plus decision-making, productivity, and Claude Code power tools.
+**🆕 Latest release (v16.0.0 — Multi-Platform):** the library goes cross-tool. A single-source export generator produces ready-to-use ChatGPT and Gemini prompts from every skill, native Hermes Agent install support, three stdlib Python helper scripts, explicit skill tiers, and an upgraded Skill Playground. See the [changelog](#-changelog).
 ---
 
 ## Contents
@@ -84,19 +85,23 @@ two portable parts: a small **frontmatter** block (`name` + `description`) and a
 **markdown body** that is just a well-structured set of instructions and output templates.
 The body is plain English — so it works anywhere a capable model reads instructions.
 
+There are two kinds of support. **Native `SKILL.md` agents** read the file as-is and
+auto-discover skills from the `description` frontmatter. **Other tools** take the markdown
+body as a system prompt — for those we ship ready-made [exports](#ready-to-use-exports).
+
 | Platform | How it works | Auto-trigger? |
 |---|---|---|
 | **Claude Code** (CLI / desktop / web / IDE) | Native. Install via the plugin marketplace; Claude loads a skill automatically when your request matches its description. | ✅ Yes |
+| **Hermes Agent** (Nous Research) | Native — same open `SKILL.md` standard. Run `python3 scripts/sync-hermes-skills.py` to install into `~/.hermes/skills/`; Hermes auto-discovers them. | ✅ Yes |
 | **Claude.ai & Claude API** | Upload a skill, or paste the body in as a system prompt / project instruction. | ⚙️ Manual |
-| **Other coding agents that read the `SKILL.md` format** (e.g. Codex, Gemini CLI, Cursor) | Point the agent at the skill folder, or paste the body. The frameworks are tool-agnostic; only the auto-discovery mechanism differs per tool. | ⚙️ Varies by tool |
-| **General chat LLMs** (ChatGPT, Gemini, Copilot, etc.) | Copy the body of any `SKILL.md` into a custom instruction / system prompt / custom GPT. You keep the full framework and output format. | ❌ Paste per use |
+| **Other coding agents that read the `SKILL.md` format** (e.g. Codex, Gemini CLI, Cursor) | Point the agent at the `skills/` folder, or paste the body. The frameworks are tool-agnostic; only the auto-discovery mechanism differs per tool. | ⚙️ Varies by tool |
+| **ChatGPT & Gemini** | Copy a ready-made export (below) into a Custom GPT or Gem's instructions. You keep the full framework and output format. | ❌ Paste per use |
 
 **What's verified vs. what varies:** the skill **bodies** — the frameworks, rubrics, and
 output templates that do the actual work — are model-agnostic and have been used across
-Claude and other chat LLMs. What's **Claude Code-specific** is the convenience layer:
-plugin install, automatic skill discovery from the `description`, and the helper-script
-invocation flow. On other tools you copy the body in manually and lose only the
-auto-triggering, not the substance.
+Claude and other chat LLMs. Native `SKILL.md` agents (Claude Code, Hermes) also get the
+convenience layer: automatic skill discovery from the `description`. On chat LLMs you paste
+the body in manually and lose only the auto-triggering, not the substance.
 
 ### Ready-to-use exports
 
@@ -107,8 +112,15 @@ maintained twice:
 - **ChatGPT** — copy any [`exports/chatgpt/<bundle>/<skill>/SYSTEM_PROMPT.md`](exports/chatgpt/) straight into a Custom GPT's instructions.
 - **Google Gemini** — copy any [`exports/gemini/<bundle>/<skill>/GEM_INSTRUCTIONS.md`](exports/gemini/) into a Gem's instructions.
 
-The skill body in `skills/<name>/SKILL.md` is the single source of truth. Regenerate (or
-add a new platform — it's a few lines in the `PLATFORMS` registry) with:
+Native `SKILL.md` agents don't need exports — install the skills directly:
+
+```bash
+# Hermes Agent (Nous Research) — installs skills/ into ~/.hermes/skills/
+python3 scripts/sync-hermes-skills.py            # copy (use --link to symlink, --dry-run to preview)
+```
+
+The skill body in `skills/<name>/SKILL.md` is the single source of truth. Regenerate the
+chat-LLM exports (or add a new platform — it's a few lines in the `PLATFORMS` registry) with:
 
 ```bash
 node scripts/build-exports.mjs            # regenerate all platform exports
@@ -270,10 +282,25 @@ More templates will follow. If you want to contribute one, see the [template con
 
 ## 📋 Changelog
 
-The highlights are below. For the structured, [Keep a Changelog](https://keepachangelog.com/)-format history (including unreleased changes), see **[CHANGELOG.md](CHANGELOG.md)**.
+The highlights are below. For the structured, [Keep a Changelog](https://keepachangelog.com/)-format history, see **[CHANGELOG.md](CHANGELOG.md)**.
+
+### 🆕 What's New in v16.0.0 — Multi-Platform
+
+The library stops being Claude-only and becomes a portable, single-source-of-truth project:
+
+- **Runs on more platforms.** Native install for **Hermes Agent** (same open `SKILL.md` standard) via `scripts/sync-hermes-skills.py`, plus ready-to-paste **ChatGPT** and **Gemini** exports generated from every skill.
+- **One source, many targets.** `scripts/build-exports.mjs` renders per-platform files from each `SKILL.md` body — nothing is maintained twice — with a `PLATFORMS` registry that makes adding a tool a few lines, and a CI guard that fails on drift.
+- **Three stdlib Python helpers** for flagship skills (sprint capacity, RICE scoring, customer-health scoring).
+- **Explicit skill tiers** (`TIERS.md` + `skill-tiers.json`): 46 Production-Ready, a curated Experimental set, Stable as default — surfaced in the README and the playground.
+- **Upgraded Skill Playground**: tier filter + badges and a "use this skill in another tool" copy panel.
+- **Repo hygiene**: `CHANGELOG.md`, `SKILL-AUTHORING-STANDARD.md`, refreshed `SECURITY.md`, `.gitignore`, and a Related Projects section.
 
 <details>
-<summary><strong>Release history — v6.0.0 → v14.0.0</strong> (click to expand)</summary>
+<summary><strong>Release history — v6.0.0 → v15.0.0</strong> (click to expand)</summary>
+
+### 🆕 What's New in v15.0.0 — Skill Playground (browser UI) 🌐
+
+Run any skill **without installing anything** — a zero-backend web app that executes skills in your browser with your own Claude API key. Tile gallery with search and bundle filter, click-to-run forms auto-generated from each skill's inputs, live streaming output with copy / download, and an auto-deploy to GitHub Pages on every push to `main`. **▶ Live: [mohitagw15856.github.io/pm-claude-skills](https://mohitagw15856.github.io/pm-claude-skills/)**
 
 ### 🆕 What's New in v14.0.0 — Writers & Content Creators + 7 Community Skills
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,9 @@ That said, security matters here in two specific ways: **skill file safety** and
 
 | Version | Supported |
 |---|---|
-| v14.x (latest) | ✅ Active |
-| v12.x – v13.x | ✅ Security fixes only |
-| < v12.0.0 | ❌ No longer supported |
+| v16.x (latest) | ✅ Active |
+| v14.x – v15.x | ✅ Security fixes only |
+| < v14.0.0 | ❌ No longer supported |
 
 Because skills are plain markdown, "support" means we review and correct any reported
 safety issue (prompt injection, unsafe instructions) in the listed versions.

--- a/scripts/sync-hermes-skills.py
+++ b/scripts/sync-hermes-skills.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Install this library's skills into Hermes Agent (Nous Research).
+
+Hermes reads the same `SKILL.md` standard as Claude Code — it auto-discovers
+skills from its skills directory (default `~/.hermes/skills/`) using the
+`description` frontmatter. So there is **no format conversion**: this script just
+places the canonical `skills/<name>/` folders (SKILL.md + any scripts/) where
+Hermes can find them.
+
+Pure Python standard library — no dependencies, no network access.
+
+Examples
+--------
+    # Copy all skills into ~/.hermes/skills/pm-claude-skills/
+    python3 scripts/sync-hermes-skills.py
+
+    # Symlink instead (so `git pull` updates them in place)
+    python3 scripts/sync-hermes-skills.py --link
+
+    # Install into a custom location, un-namespaced (flat)
+    python3 scripts/sync-hermes-skills.py --target ./my-project/skills --flat
+
+    # See what would happen without writing anything
+    python3 scripts/sync-hermes-skills.py --dry-run
+
+Uninstall: delete the `pm-claude-skills/` folder inside the target directory.
+"""
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / "skills"
+DEFAULT_TARGET = Path.home() / ".hermes" / "skills"
+NAMESPACE = "pm-claude-skills"
+
+
+def discover_skills() -> list[Path]:
+    """Return every skills/<name>/ folder that contains a SKILL.md."""
+    if not SKILLS_DIR.is_dir():
+        raise FileNotFoundError(f"Cannot find skills directory at {SKILLS_DIR}")
+    return sorted(p for p in SKILLS_DIR.iterdir() if (p / "SKILL.md").is_file())
+
+
+def install(skills: list[Path], dest: Path, *, link: bool, dry_run: bool) -> int:
+    count = 0
+    for skill in skills:
+        target = dest / skill.name
+        action = "symlink" if link else "copy"
+        if dry_run:
+            print(f"  would {action}: {skill.name} -> {target}")
+            count += 1
+            continue
+
+        # Replace any existing install so re-running is idempotent.
+        if target.is_symlink() or target.is_file():
+            target.unlink()
+        elif target.is_dir():
+            shutil.rmtree(target)
+
+        if link:
+            target.symlink_to(skill, target_is_directory=True)
+        else:
+            shutil.copytree(skill, target)
+        count += 1
+    return count
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--target", type=Path, default=DEFAULT_TARGET,
+                        help=f"Hermes skills directory (default: {DEFAULT_TARGET}).")
+    parser.add_argument("--flat", action="store_true",
+                        help=f"Install directly into --target instead of a '{NAMESPACE}/' subfolder.")
+    parser.add_argument("--link", action="store_true",
+                        help="Symlink each skill instead of copying (updates follow git pull).")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Show what would happen without writing anything.")
+    args = parser.parse_args(argv)
+
+    try:
+        skills = discover_skills()
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    if not skills:
+        print("No skills found to install.", file=sys.stderr)
+        return 1
+
+    dest = args.target if args.flat else args.target / NAMESPACE
+    print(f"{'[dry-run] ' if args.dry_run else ''}Installing {len(skills)} skills into {dest}")
+    if not args.dry_run:
+        dest.mkdir(parents=True, exist_ok=True)
+
+    count = install(skills, dest, link=args.link, dry_run=args.dry_run)
+
+    print(f"\n{'Would install' if args.dry_run else 'Installed'} {count} skills "
+          f"({'symlinked' if args.link else 'copied'}).")
+    if not args.dry_run:
+        print(f"Restart Hermes Agent — it auto-discovers SKILL.md skills from {args.target} "
+              f"and activates them by their description.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        rc = main()
+    except BrokenPipeError:
+        # Output was truncated by a closed pipe (e.g. `| head`); exit quietly.
+        try:
+            sys.stdout.close()
+        except Exception:
+            pass
+        rc = 0
+    raise SystemExit(rc)

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Skill Playground — Product Notes</title>
-  <meta name="description" content="Run any of 170+ Claude skills from your browser with your own API key. Pick a skill tile, fill the inputs, get the output." />
+  <meta name="description" content="Run any of 170+ professional skills in your browser with your own Claude API key — or copy each one as a ready-made ChatGPT or Gemini prompt." />
   <link rel="stylesheet" href="styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js"></script>
@@ -15,7 +15,7 @@
       <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
       <div class="brand-text">
         <h1>Skill Playground</h1>
-        <p class="tagline">170+ Claude skills — pick one and run it with your own key.</p>
+        <p class="tagline">170+ professional skills — run with your Claude key, or copy for ChatGPT &amp; Gemini.</p>
       </div>
     </div>
     <div class="key-area">


### PR DESCRIPTION
Completes the v16.0.0 multi-platform release. PR #25 squash-merged everything **except** its final commit (Hermes + rebrand + version docs), so `main` currently has the export generator/tiers but not Hermes support or the rebrand. This re-applies that commit on top of `main` and corrects the version.

## Why v16.0.0 (not v15)
`v15.0.0` is **already a published release** ("Skill Playground", June 9). So this multi-platform work is **v16.0.0**, and the changelog now also records the real v15.0.0 in its history.

## Changes
- **Hermes Agent support (native).** `scripts/sync-hermes-skills.py` installs `skills/` into `~/.hermes/skills/` (copy or `--link` symlink, `--flat`, `--dry-run`). Hermes uses the same open `SKILL.md` standard — no conversion; it auto-discovers by `description`, like Claude Code.
- **Multi-platform rebrand.** README title, tagline, intro, and a new "works with" platforms badge cover Claude, ChatGPT, Gemini, and Hermes. The Works-With table now splits native `SKILL.md` agents from paste-in chat LLMs. Repo name, marketplace ID, and install commands are unchanged.
- **Version → v16.0.0**: README badge + "What's New", `CHANGELOG.md` (with a back-filled v15.0.0 Skill Playground entry), `SECURITY.md` support table, and the playground tagline/meta.

## Verification
- `scripts/sync-hermes-skills.py`: `py_compile` OK; tested copy, `--link`, `--flat`, `--dry-run`, idempotent re-run, and `| head` (no BrokenPipe traceback).
- Diff vs `main` is exactly this delta (5 files); no leftover mislabeled v15 "Multi-Platform" strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_