### PR TITLE
Subagents, slash commands, skill scaffolder, and discoverability pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
 ## [Unreleased]
 
 ### Added
+- **Subagents & slash commands** — the library now ships content beyond skills:
+  4 Claude Code subagents in [`agents/`](agents/) (`pm-partner`, `sprint-master`,
+  `cs-guardian`, `launch-captain`) and 6 slash commands in [`commands/`](commands/)
+  (`/prd`, `/rice`, `/sprint-plan`, `/health-scorecard`, `/retro`, `/exec-summary`).
+  `install.sh --agent claude` now installs skills **+** agents **+** commands.
+- **Skill scaffolding generator** — `scripts/new-skill.mjs` (`npm run new-skill`) creates a
+  `SKILL.md` that already passes SkillCheck, lowering the barrier to contributing.
+- **`package.json`** — `npm run` entry points (`new-skill`, `skillcheck`, `build:exports`,
+  `build:web`, `check`) so the repo reads as a real project.
+- **README discoverability pass** — keyword-rich H1 (Agent Skills for Claude, ChatGPT,
+  Gemini, Cursor, Codex & Hermes), subagent/command count badges, and a Star History chart.
 - **SkillCheck validator** — `scripts/skillcheck.mjs` validates every `SKILL.md` against
   the authoring standard (frontmatter, name/folder match, trigger + produces clauses,
   required headings, tier referential integrity). Errors fail CI; `--strict` also fails on

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# 🧠 PM Skills — 167 Professional Skills for Claude, ChatGPT, Gemini & Hermes
+# 🧠 PM Skills — 167 Professional Agent Skills for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes
+
+> Open-source **Agent Skills** (`SKILL.md`) + subagents + slash commands for every profession — one source, every AI coding tool.
 
 [![Stars](https://img.shields.io/github/stars/mohitagw15856/pm-claude-skills?style=social)](https://github.com/mohitagw15856/pm-claude-skills/stargazers)
 [![Skills](https://img.shields.io/badge/skills-167-blue)](https://github.com/mohitagw15856/pm-claude-skills)
-[![Platforms](https://img.shields.io/badge/works%20with-Claude%20%7C%20ChatGPT%20%7C%20Gemini%20%7C%20Hermes-8A2BE2)](#-works-with--cross-tool-compatibility)
+[![Subagents](https://img.shields.io/badge/subagents-4-blueviolet)](agents/)
+[![Commands](https://img.shields.io/badge/slash%20commands-6-blueviolet)](commands/)
+[![Platforms](https://img.shields.io/badge/works%20with-Claude%20%7C%20ChatGPT%20%7C%20Gemini%20%7C%20Cursor%20%7C%20Codex%20%7C%20Hermes-8A2BE2)](#-works-with--cross-tool-compatibility)
 [![SkillCheck](https://img.shields.io/github/actions/workflow/status/mohitagw15856/pm-claude-skills/skillcheck.yml?branch=main&label=SkillCheck)](.github/workflows/skillcheck.yml)
 [![Version](https://img.shields.io/badge/version-16.0.0-brightgreen)](https://github.com/mohitagw15856/pm-claude-skills/releases)
 [![Install](https://img.shields.io/badge/Install%20in%20Claude%20Code-2%20minutes-orange)](https://github.com/mohitagw15856/pm-claude-skills#-quick-install-2-minutes)
@@ -21,6 +25,7 @@ A community-built library of professional skills for every field — product man
 
 - [🚀 Quick Install](#-quick-install-2-minutes)
 - [🔌 Works With — Cross-Tool Compatibility](#-works-with--cross-tool-compatibility)
+- [🤖 Subagents & Slash Commands](#-subagents--slash-commands)
 - [🌐 Skill Playground — try any skill in your browser](#-skill-playground--try-any-skill-in-your-browser)
 - [📦 Plugin Directory](#-plugin-directory)
 - [🤖 Building Blocks for Agent Templates](#-building-blocks-for-agent-templates)
@@ -148,6 +153,33 @@ node scripts/build-exports.mjs --check    # CI: fail if exports are stale
 ```
 
 > Prefer a hand-curated ChatGPT collection? There's also a [companion Custom GPT library](#-companion-repository--chatgpt-custom-gpts) built from the same frameworks.
+
+---
+
+## 🤖 Subagents & Slash Commands
+
+It's not just skills. The library also ships **Claude Code subagents** and **slash commands** built on top of the strongest skills, so common workflows are one delegation or one command away.
+
+**Subagents** ([`agents/`](agents/)) — focused personas Claude delegates to automatically by description:
+
+| Agent | Use it for |
+|---|---|
+| [`pm-partner`](agents/pm-partner.md) | PRDs, prioritisation, stakeholder updates, exec summaries |
+| [`sprint-master`](agents/sprint-master.md) | Sprint planning, retros, velocity, user stories |
+| [`cs-guardian`](agents/cs-guardian.md) | Account health, churn, renewals, escalations, QBRs |
+| [`launch-captain`](agents/launch-captain.md) | Positioning, GTM, launch checklists, competitor teardowns |
+
+**Slash commands** ([`commands/`](commands/)) — run a skill on whatever you pass:
+
+`/prd` · `/rice` · `/sprint-plan` · `/health-scorecard` · `/retro` · `/exec-summary`
+
+Install everything for Claude Code in one go (skills **+** subagents **+** commands):
+
+```bash
+./scripts/install.sh --agent claude       # ~/.claude/{skills,agents,commands}
+```
+
+Commands whose skill ships a Python helper (RICE, sprint capacity, customer health) run it to **compute** results, not estimate them.
 
 ---
 
@@ -861,9 +893,12 @@ This is an open-source community library. If you've built a skill that saves you
 **How to contribute:**
 
 1. Fork this repo
-2. Create a new folder: `skills/your-skill-name/`
-3. Add a `SKILL.md` file following the template below
+2. Scaffold a skill that already passes validation: `npm run new-skill -- --name your-skill-name`
+   (or copy the template below into `skills/your-skill-name/SKILL.md`)
+3. Fill in the sections, then check it: `npm run skillcheck`
 4. Raise a pull request with a short description of what the skill does and why you built it
+
+> CI runs **SkillCheck** on every PR — `node scripts/skillcheck.mjs` validates structure and must pass.
 
 **SKILL.md template:**
 ---
@@ -1041,6 +1076,10 @@ Stars unlock the next wave of skills. Here's the roadmap:
 **[⭐ Star this repo to unlock the next milestone →](https://github.com/mohitagw15856/pm-claude-skills)**
 
 Want a specific skill built? [Vote or request in SKILL_REQUEST.md](SKILL_REQUEST.md).
+
+### 📈 Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=mohitagw15856/pm-claude-skills&type=Date)](https://star-history.com/#mohitagw15856/pm-claude-skills&Date)
 
 ---
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,20 @@
+# Subagents
+
+Claude Code **subagents** built from this library's skills — focused personas Claude can delegate to automatically based on their `description`.
+
+| Agent | Use it for | Skills it leans on |
+|---|---|---|
+| `pm-partner` | PRDs, prioritisation, stakeholder updates, exec summaries | prd-template, rice-prioritisation, stakeholder-update, executive-summary |
+| `sprint-master` | Sprint planning, retros, velocity, user stories | sprint-planning, retro-analysis, sprint-velocity-analysis, user-story-writer |
+| `cs-guardian` | Account health, churn, renewals, escalations, QBRs | cs-health-scorecard, churn-analysis, renewal-playbook, qbr-deck |
+| `launch-captain` | Positioning, GTM, launch checklists, competitor teardowns | product-positioning-doc, go-to-market, product-launch-checklist, competitor-teardown |
+
+## Install
+
+```bash
+./scripts/install.sh --agent claude       # installs skills + agents + commands into ~/.claude/
+# or copy manually:
+cp agents/*.md ~/.claude/agents/
+```
+
+Then in Claude Code, ask for the kind of work an agent covers and Claude will delegate to it — or invoke explicitly (e.g. "use the cs-guardian subagent"). Agents that ship a helper script will run it to compute results.

--- a/agents/cs-guardian.md
+++ b/agents/cs-guardian.md
@@ -1,0 +1,19 @@
+---
+name: cs-guardian
+description: Customer success partner for account health, churn risk, renewals, escalations, and QBRs. Use to score an account, diagnose churn, prep a renewal or QBR, or write an escalation brief. Computes the weighted health score programmatically.
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: inherit
+---
+
+You protect and grow customer accounts with evidence, not gut feel.
+
+## How you work
+- Apply the relevant skill: `cs-health-scorecard`, `churn-analysis`, `renewal-playbook`, `cs-escalation-brief`, `qbr-deck`, or `customer-success-plan`.
+- For health scores, **run** `skills/cs-health-scorecard/scripts/health_score.py` to compute the weighted /100 total and RAG band.
+- Every score and risk must cite specific evidence (usage, tickets, sponsor status) — never "low engagement" with no detail.
+- Recommended actions always have a named owner and a deadline.
+
+## Quality bar
+- No Green status for an account with unresolved P1s or a missing executive sponsor.
+- Renewal forecasts are calibrated against pipeline reality, with ARR at risk quantified.
+- Distinguish product usage from value delivered.

--- a/agents/launch-captain.md
+++ b/agents/launch-captain.md
@@ -1,0 +1,19 @@
+---
+name: launch-captain
+description: Go-to-market and launch partner for positioning, GTM plans, launch checklists, competitor teardowns, and press/announcements. Use to position a product, plan a launch, or analyse a competitor.
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: inherit
+---
+
+You take products to market with sharp positioning and a calm, complete launch plan.
+
+## How you work
+- Apply the relevant skill: `product-positioning-doc`, `go-to-market`, `product-launch-checklist`, `competitor-teardown`, `press-release`, or `content-calendar`.
+- Lead with the customer and the differentiated value, not the feature list.
+- For launches, produce a phased checklist with owners, dates, and a go/no-go bar.
+- Ask for the target segment, the alternative customers use today, and the proof points before writing positioning.
+
+## Quality bar
+- Positioning names the category, the alternative, and the one thing you do better — with evidence.
+- Launch plans have a rollback/contingency path and a single accountable owner per workstream.
+- Competitor teardowns end with specific, exploitable gaps — not a feature grid.

--- a/agents/pm-partner.md
+++ b/agents/pm-partner.md
@@ -1,0 +1,19 @@
+---
+name: pm-partner
+description: Strategic product-management partner. Use for PRDs, prioritisation, stakeholder updates, executive summaries, and turning vague asks into structured product thinking. Delegates to the matching skill and asks for missing inputs instead of guessing.
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: inherit
+---
+
+You are a senior product manager acting as a hands-on partner. You turn fuzzy requests into clear, decision-ready artifacts.
+
+## How you work
+- Identify what the user actually needs (a PRD, a prioritisation, a stakeholder update, an exec summary) and apply the matching skill from this library — `prd-template`, `rice-prioritisation`, `feature-prioritisation`, `stakeholder-update`, `executive-summary`, `roadmap-narrative`.
+- **Ask for missing inputs** before producing output. Never invent metrics, dates, or user counts.
+- Prefer structure: goals, options with trade-offs, a recommendation, and the evidence behind it.
+- When a skill ships a helper script (e.g. `skills/rice-prioritisation/scripts/rice_calculator.py`), run it to compute results rather than estimating.
+
+## Quality bar
+- Every recommendation states the trade-off it accepts.
+- Outputs are scannable: headings, tables, and a one-line "so what".
+- Flag assumptions explicitly and separate them from facts.

--- a/agents/sprint-master.md
+++ b/agents/sprint-master.md
@@ -1,0 +1,19 @@
+---
+name: sprint-master
+description: Agile delivery partner for sprint planning, retrospectives, velocity analysis, and user stories. Use when planning a sprint, running a retro, estimating capacity, or breaking epics into stories. Uses the capacity calculator to size commitments.
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: inherit
+---
+
+You run agile delivery rituals with discipline and a bias for realistic commitments.
+
+## How you work
+- Apply the relevant skill: `sprint-planning`, `retro-analysis`, `sprint-velocity-analysis`, `user-story-writer`, or `sprint-brief`.
+- For capacity, **run** `skills/sprint-planning/scripts/capacity_calculator.py` with the team's numbers — recommend committing to ~80% of velocity, never 100%.
+- Insist on acceptance criteria for every story; flag any story without them as a blocker.
+- Split anything estimated at 8+ points before it enters the sprint.
+
+## Quality bar
+- Sprint goals are outcome-focused and pass/fail at sprint end, never task lists.
+- Carry-overs are counted against capacity before new work is pulled in.
+- Retros end with owned, dated action items — not vibes.

--- a/commands/README.md
+++ b/commands/README.md
@@ -1,0 +1,22 @@
+# Slash Commands
+
+Claude Code **slash commands** that run a skill on whatever you pass them.
+
+| Command | Does | Skill |
+|---|---|---|
+| `/prd` | Draft a PRD from an idea | prd-template |
+| `/rice` | Score & rank initiatives (RICE) | rice-prioritisation |
+| `/sprint-plan` | Plan a sprint with a calibrated commitment | sprint-planning |
+| `/health-scorecard` | Weighted customer health scorecard | cs-health-scorecard |
+| `/retro` | Structured sprint retrospective | retro-analysis |
+| `/exec-summary` | Crisp executive summary | executive-summary |
+
+## Install
+
+```bash
+./scripts/install.sh --agent claude       # installs skills + agents + commands into ~/.claude/
+# or copy manually:
+cp commands/*.md ~/.claude/commands/
+```
+
+Then run, e.g. `/rice` followed by your initiatives. Commands whose skill ships a Python helper (RICE, sprint, health) will run it to compute results.

--- a/commands/exec-summary.md
+++ b/commands/exec-summary.md
@@ -1,0 +1,8 @@
+---
+description: Compress a document or update into a crisp executive summary.
+argument-hint: [text, decision, or document to summarise]
+---
+
+Apply the **executive-summary** skill to: $ARGUMENTS
+
+Lead with the decision or "so what", then the key points and the ask. Keep it scannable, quantify where possible, and surface risks and the recommendation up front. No filler.

--- a/commands/health-scorecard.md
+++ b/commands/health-scorecard.md
@@ -1,0 +1,8 @@
+---
+description: Build a weighted customer health scorecard for an account.
+argument-hint: [account name + usage/support/commercial signals]
+---
+
+Apply the **cs-health-scorecard** skill to: $ARGUMENTS
+
+Score each dimension 1–5 with specific evidence, then run `skills/cs-health-scorecard/scripts/health_score.py` to compute the weighted /100 total and RAG band. Produce the scorecard, top risks (specific, not vague), owned/dated actions, and a calibrated renewal forecast with ARR at risk.

--- a/commands/prd.md
+++ b/commands/prd.md
@@ -1,0 +1,8 @@
+---
+description: Draft a product requirements document from a feature idea or brief.
+argument-hint: [feature or problem to spec]
+---
+
+Apply the **prd-template** skill to produce a complete PRD for: $ARGUMENTS
+
+Ask for any missing essentials first (problem, target user, success metric, scope). Do not invent metrics or dates. Produce a structured PRD with problem, goals/non-goals, user stories, requirements, success metrics, and open questions.

--- a/commands/retro.md
+++ b/commands/retro.md
@@ -1,0 +1,8 @@
+---
+description: Run a structured sprint retrospective from notes.
+argument-hint: [what happened this sprint — wins, misses, blockers]
+---
+
+Apply the **retro-analysis** skill to: $ARGUMENTS
+
+Surface themes (what went well, what didn't, what to change), separate symptoms from root causes, and end with owned, dated action items. Keep it blameless and specific.

--- a/commands/rice.md
+++ b/commands/rice.md
@@ -1,0 +1,8 @@
+---
+description: Score and rank initiatives with the RICE framework.
+argument-hint: [list of initiatives, or a file/path of them]
+---
+
+Apply the **rice-prioritisation** skill to: $ARGUMENTS
+
+Gather or estimate Reach, Impact, Confidence, and Effort for each item. If the data is structured, run `skills/rice-prioritisation/scripts/rice_calculator.py` to compute and rank the scores and flag quick wins / moonshots / low-confidence items. Present a ranked table, a recommended sequence, and the data gaps that would most improve accuracy.

--- a/commands/sprint-plan.md
+++ b/commands/sprint-plan.md
@@ -1,0 +1,8 @@
+---
+description: Plan a sprint with a calibrated, realistic commitment.
+argument-hint: [team size, velocity, backlog items, known absences]
+---
+
+Apply the **sprint-planning** skill using: $ARGUMENTS
+
+Run `skills/sprint-planning/scripts/capacity_calculator.py` with the team's numbers to compute the recommended commitment (cap at ~80% of velocity). Produce an outcome-focused sprint goal, a capacity-fit backlog with acceptance criteria, carry-over accounting, risks, and a planning agenda. Flag any 8+ point story for splitting.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "pm-claude-skills",
+  "version": "16.0.0",
+  "private": true,
+  "type": "module",
+  "description": "167 professional agent skills for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes — plus subagents, slash commands, and a multi-platform export pipeline.",
+  "license": "MIT",
+  "homepage": "https://github.com/mohitagw15856/pm-claude-skills",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mohitagw15856/pm-claude-skills.git"
+  },
+  "scripts": {
+    "new-skill": "node scripts/new-skill.mjs",
+    "skillcheck": "node scripts/skillcheck.mjs",
+    "build:exports": "node scripts/build-exports.mjs",
+    "build:web": "node web/build-skills.mjs",
+    "check": "node scripts/skillcheck.mjs && node scripts/build-exports.mjs --check"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,6 +100,24 @@ else
     place "${skill%/}" "$TARGET/$name"
     count=$((count + 1))
   done
+
+  # Claude Code also gets subagents and slash commands (siblings of skills/).
+  if [ "$AGENT" = "claude" ]; then
+    claude_root="$(dirname "$TARGET")"   # ~/.claude
+    for kind in agents commands; do
+      src="$REPO_DIR/$kind"
+      [ -d "$src" ] || continue
+      dest="$claude_root/$kind"
+      [ "$DRYRUN" = 1 ] || mkdir -p "$dest"
+      for f in "$src"/*.md; do
+        base="$(basename "$f")"
+        [ "$base" = "README.md" ] && continue
+        if [ "$DRYRUN" = 1 ]; then echo "  would install $kind/$base -> $dest/$base";
+        else cp "$f" "$dest/$base"; fi
+        count=$((count + 1))
+      done
+    done
+  fi
 fi
 
 echo

--- a/scripts/new-skill.mjs
+++ b/scripts/new-skill.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+// Scaffold a new skill that already passes SkillCheck. Lowers the barrier to
+// contributing — fill in the blanks instead of remembering the whole structure.
+//
+// Usage:
+//   node scripts/new-skill.mjs --name churn-forecaster --description "..."
+//   node scripts/new-skill.mjs            # interactive (prompts for the basics)
+//   npm run new-skill -- --name my-skill
+//
+// No dependencies.
+import { writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createInterface } from 'node:readline/promises';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--force') out.force = true;
+    else if (a.startsWith('--')) { out[a.slice(2)] = argv[i + 1]; i++; }
+  }
+  return out;
+}
+
+const titleCase = (name) =>
+  name.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+
+function template({ name, title, description }) {
+  return `---
+name: ${name}
+description: "${description}"
+---
+
+# ${title} Skill
+
+One-line summary of the value this skill delivers. <!-- TODO: rewrite -->
+
+## What This Skill Produces
+
+- <!-- TODO: the concrete deliverable(s) this skill outputs -->
+
+## Required Inputs
+
+Ask for (if not already provided):
+- <!-- TODO: the inputs to gather; never invent them -->
+
+## Process
+
+1. <!-- TODO: the steps the skill follows -->
+
+## Output Format
+
+<!-- TODO: a concrete template (headings/tables) of the final artifact -->
+
+## Quality Checks
+
+- [ ] <!-- TODO: a check the output must pass before hand-off -->
+
+## Anti-Patterns
+
+- [ ] Do not <!-- TODO: the mistake this skill prevents -->
+`;
+}
+
+async function resolveInputs(args) {
+  let { name, title, description } = args;
+  const interactive = !name && process.stdin.isTTY;
+  if (interactive) {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    name = (await rl.question('Skill name (lowercase-hyphenated): ')).trim();
+    description = (await rl.question('Description (what / use when / produces): ')).trim();
+    rl.close();
+  }
+  if (!name) throw new Error('Provide --name (lowercase-hyphenated), or run in a terminal for prompts.');
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(name)) throw new Error(`Invalid name "${name}". Use lowercase letters, numbers, and hyphens.`);
+  title = title || titleCase(name);
+  // A default description that already satisfies SkillCheck (what / use when / produces).
+  description = description || `Summarise what ${title} does in one line. Use when asked to [trigger phrases the user would say]. Produces [the concrete artifact].`;
+  return { name, title, description };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  let inputs;
+  try {
+    inputs = await resolveInputs(args);
+  } catch (e) {
+    console.error(`Error: ${e.message}`);
+    process.exit(1);
+  }
+
+  const dir = join(root, 'skills', inputs.name);
+  const file = join(dir, 'SKILL.md');
+  if (existsSync(file) && !args.force) {
+    console.error(`Error: ${file} already exists (use --force to overwrite).`);
+    process.exit(1);
+  }
+
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(file, template(inputs));
+
+  console.log(`Created skills/${inputs.name}/SKILL.md`);
+  console.log('\nNext:');
+  console.log(`  1. Fill in the TODO sections.`);
+  console.log(`  2. node scripts/skillcheck.mjs        # validate it`);
+  console.log(`  3. node web/build-skills.mjs && node scripts/build-exports.mjs   # refresh generated artifacts`);
+}
+
+main();


### PR DESCRIPTION
Growth-focused additions from studying `alirezarezvani/claude-skills` (~18k★). Three levers: **breadth** of content types, **lower contribution friction**, and **discoverability**.

## Breadth — it's not just skills anymore
- **`agents/`** — 4 Claude Code **subagents** Claude can auto-delegate to: `pm-partner`, `sprint-master`, `cs-guardian`, `launch-captain`. Each leans on the strongest skills and **runs their Python helpers** to compute results.
- **`commands/`** — 6 **slash commands**: `/prd`, `/rice`, `/sprint-plan`, `/health-scorecard`, `/retro`, `/exec-summary`.
- `install.sh --agent claude` now installs **skills + agents + commands** into `~/.claude/` (182 items); other agents are unaffected.

## Lower contribution friction
- **`scripts/new-skill.mjs`** (`npm run new-skill -- --name x`) scaffolds a `SKILL.md` that **already passes SkillCheck** — interactive prompts or flags.
- **`package.json`** exposes `npm run` entry points (`new-skill`, `skillcheck`, `build:exports`, `build:web`, `check`) so the repo reads as a real project.

## Discoverability (the biggest "fame" gap)
- Keyword-rich **H1**: *"167 Professional Agent Skills for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes"* + an Agent-Skills tagline.
- **Subagent / slash-command count badges**, a **Subagents & Slash Commands** section, and a **Star History chart**.
- Contributing now points at the scaffolder + SkillCheck.

## Verification
- SkillCheck: 0 errors / 172 skills (and the scaffolder's output passes clean).
- `build-exports --check` and `web/skills.json` in sync; `npm run check` green.
- All `*.mjs` pass `node --check`; `install.sh` passes `bash -n`; tested `--agent claude` installs 172 skills + 4 agents + 6 commands, and that codex/others don't pick up agents.
- `package.json` valid; agent/command frontmatter well-formed.

### Still your call (separate, manual — can't be done from here)
GitHub **topics** + **About** description are repo settings, not files. Suggested topics: `claude-skills, agent-skills, claude-code, skill-md, chatgpt, gemini, cursor, codex, hermes-agent, ai-agents, subagents, slash-commands, prompt-engineering, product-management, llm-tools`. Suggested About: *"167 professional Agent Skills (SKILL.md) + subagents + slash commands for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes — one source, every AI tool."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_