### PR TITLE
npx CLI installer (cross-platform) + v17.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [17.0.0] — Agents, Commands & the npx CLI — 2026-06-17
+
 ### Added
+- **`npx pm-claude-skills` CLI** — a cross-platform Node installer (`bin/cli.mjs`, no bash,
+  no git, works on Windows) that installs skills into any agent:
+  `npx pm-claude-skills add --agent <claude|hermes|codex|openclaw|cursor>` with
+  `--link` / `--target` / `--dry-run`. For `claude` it installs skills + subagents +
+  commands. `package.json` is now a publishable package (`bin`, `files`, keywords).
 - **Subagents & slash commands** — the library now ships content beyond skills:
   4 Claude Code subagents in [`agents/`](agents/) (`pm-partner`, `sprint-master`,
   `cs-guardian`, `launch-captain`) and 6 slash commands in [`commands/`](commands/)
@@ -153,7 +162,8 @@ Earlier releases (v1.0.0 – v5.0.0) predate this changelog. See the
 [article series](README.md#-the-article-series) for the full history of how the
 library grew from the first PM toolkit to 100+ skills.
 
-[Unreleased]: https://github.com/mohitagw15856/pm-claude-skills/compare/v16.0.0...HEAD
+[Unreleased]: https://github.com/mohitagw15856/pm-claude-skills/compare/v17.0.0...HEAD
+[17.0.0]: https://github.com/mohitagw15856/pm-claude-skills/compare/v16.0.0...v17.0.0
 [16.0.0]: https://github.com/mohitagw15856/pm-claude-skills/compare/v15.0.0...v16.0.0
 [15.0.0]: https://github.com/mohitagw15856/pm-claude-skills/compare/v14.0.0...v15.0.0
 [14.0.0]: https://github.com/mohitagw15856/pm-claude-skills/releases

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Commands](https://img.shields.io/badge/slash%20commands-6-blueviolet)](commands/)
 [![Platforms](https://img.shields.io/badge/works%20with-Claude%20%7C%20ChatGPT%20%7C%20Gemini%20%7C%20Cursor%20%7C%20Codex%20%7C%20Hermes-8A2BE2)](#-works-with--cross-tool-compatibility)
 [![SkillCheck](https://img.shields.io/github/actions/workflow/status/mohitagw15856/pm-claude-skills/skillcheck.yml?branch=main&label=SkillCheck)](.github/workflows/skillcheck.yml)
-[![Version](https://img.shields.io/badge/version-16.0.0-brightgreen)](https://github.com/mohitagw15856/pm-claude-skills/releases)
+[![Version](https://img.shields.io/badge/version-17.0.0-brightgreen)](https://github.com/mohitagw15856/pm-claude-skills/releases)
 [![Install](https://img.shields.io/badge/Install%20in%20Claude%20Code-2%20minutes-orange)](https://github.com/mohitagw15856/pm-claude-skills#-quick-install-2-minutes)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/sponsor-❤️-ff69b4)](https://github.com/sponsors/mohitagw15856)
@@ -18,7 +18,7 @@
 
 A community-built library of professional skills for every field — product management, engineering, customer success, marketing, social media, writers, design, legal, finance, HR, sales, operations, research, and more. Each skill is a structured `SKILL.md` file that teaches an AI assistant how to produce professional-grade outputs for your workflows. Skills run natively in **Claude Code** and **Hermes Agent** (same open `SKILL.md` standard), and ship as ready-to-paste exports for **ChatGPT** and **Gemini** — see [Works With](#-works-with--cross-tool-compatibility).
 
-**🆕 Latest release (v16.0.0 — Multi-Platform):** the library goes cross-tool. A single-source export generator produces ready-to-use ChatGPT and Gemini prompts from every skill, native Hermes Agent install support, three stdlib Python helper scripts, explicit skill tiers, and an upgraded Skill Playground. See the [changelog](#-changelog).
+**🆕 Latest release (v17.0.0 — Agents, Commands & the npx CLI):** install into any tool with one cross-platform command — `npx pm-claude-skills add --agent <tool>`. Adds 4 Claude Code subagents, 6 slash commands, Cursor `.mdc` exports, a SkillCheck validator, and a skill scaffolder. See the [changelog](#-changelog).
 ---
 
 ## Contents
@@ -39,7 +39,13 @@ A community-built library of professional skills for every field — product man
 
 ## 🚀 Quick Install (2 minutes)
 
-In Claude Code, run:
+**Any tool, one command** (Windows/macOS/Linux — needs Node):
+
+```bash
+npx pm-claude-skills add --agent claude     # or: codex · cursor · hermes · openclaw
+```
+
+**In Claude Code**, run:
 
 /plugin marketplace add mohitagw15856/pm-claude-skills
 
@@ -121,28 +127,30 @@ maintained twice:
 - **Google Gemini** — copy any [`exports/gemini/<bundle>/<skill>/GEM_INSTRUCTIONS.md`](exports/gemini/) into a Gem's instructions.
 - **Cursor** — copy any [`exports/cursor/<bundle>/<skill>/<skill>.mdc`](exports/cursor/) into `.cursor/rules/` (or use the one-liner below).
 
-### One-line install for coding agents
+### One-command install for coding agents
 
-Native `SKILL.md` agents (Claude Code, Hermes, Codex, OpenClaw) and Cursor can install every skill with a single command — each clones the library and drops the skills where the agent discovers them:
+**Cross-platform (Windows, macOS, Linux) — recommended.** One Node command installs every skill where your agent discovers them. No git, no bash:
 
 ```bash
-# OpenAI Codex
+npx pm-claude-skills add --agent claude     # skills + subagents + commands → ~/.claude/
+npx pm-claude-skills add --agent codex      # OpenAI Codex
+npx pm-claude-skills add --agent cursor     # .mdc rules → ./.cursor/rules
+npx pm-claude-skills list                   # claude · hermes · codex · openclaw · cursor
+```
+
+Add `--link` (symlink), `--target <path>`, or `--dry-run` to any `add`.
+
+**Shell one-liners** (macOS / Linux / Git Bash / WSL — *not* PowerShell):
+
+```bash
 bash <(curl -fsSL https://raw.githubusercontent.com/mohitagw15856/pm-claude-skills/main/scripts/codex-install.sh)
-
-# OpenClaw
 bash <(curl -fsSL https://raw.githubusercontent.com/mohitagw15856/pm-claude-skills/main/scripts/openclaw-install.sh)
-
-# Cursor (.mdc rules into ./.cursor/rules)
 bash <(curl -fsSL https://raw.githubusercontent.com/mohitagw15856/pm-claude-skills/main/scripts/cursor-install.sh)
 ```
 
-Already cloned? Use the unified installer for any agent (add `--link`, `--target`, or `--dry-run`):
+> **Windows / PowerShell:** use the `npx` command above (the `bash <(curl …)` form is a Unix idiom and won't run in PowerShell).
 
-```bash
-./scripts/install.sh --list                      # claude · hermes · codex · openclaw · cursor
-./scripts/install.sh --agent codex               # install for a specific agent
-python3 scripts/sync-hermes-skills.py            # Hermes equivalent (copy, or --link / --dry-run)
-```
+Already cloned? `./scripts/install.sh --agent <name>` (or `python3 scripts/sync-hermes-skills.py` for Hermes) does the same from your checkout.
 
 The skill body in `skills/<name>/SKILL.md` is the single source of truth. Regenerate the
 chat-LLM / Cursor exports (or add a new platform — it's a few lines in the `PLATFORMS` registry) with:
@@ -336,16 +344,28 @@ More templates will follow. If you want to contribute one, see the [template con
 
 The highlights are below. For the structured, [Keep a Changelog](https://keepachangelog.com/)-format history, see **[CHANGELOG.md](CHANGELOG.md)**.
 
-### 🆕 What's New in v16.0.0 — Multi-Platform
+### 🆕 What's New in v17.0.0 — Agents, Commands & the npx CLI
+
+The library grows past "just skills" and gets one-command, cross-platform install:
+
+- **`npx pm-claude-skills add --agent <tool>`** — a cross-platform Node installer (Windows/macOS/Linux, no bash, no git) for claude · hermes · codex · openclaw · cursor.
+- **4 Claude Code subagents** (`agents/`) and **6 slash commands** (`commands/`) built on the strongest skills; `--agent claude` installs skills + agents + commands together.
+- **Cursor `.mdc` exports** — third generated platform alongside ChatGPT and Gemini.
+- **SkillCheck validator** (`scripts/skillcheck.mjs`) with a CI badge, and a **skill scaffolder** (`npm run new-skill`) that emits a valid `SKILL.md`.
+- **One-line shell installers** for Codex / OpenClaw / Cursor, plus a unified `scripts/install.sh`.
+
+<details>
+<summary><strong>v16.0.0 — Multi-Platform</strong> (click to expand)</summary>
 
 The library stops being Claude-only and becomes a portable, single-source-of-truth project:
 
-- **Runs on more platforms.** Native install for **Hermes Agent** (same open `SKILL.md` standard) via `scripts/sync-hermes-skills.py`, plus ready-to-paste **ChatGPT** and **Gemini** exports generated from every skill.
-- **One source, many targets.** `scripts/build-exports.mjs` renders per-platform files from each `SKILL.md` body — nothing is maintained twice — with a `PLATFORMS` registry that makes adding a tool a few lines, and a CI guard that fails on drift.
+- **Runs on more platforms.** Native install for **Hermes Agent** (same open `SKILL.md` standard), plus ready-to-paste **ChatGPT** and **Gemini** exports generated from every skill.
+- **One source, many targets.** `scripts/build-exports.mjs` renders per-platform files from each `SKILL.md` body — nothing maintained twice — with a `PLATFORMS` registry and a CI guard that fails on drift.
 - **Three stdlib Python helpers** for flagship skills (sprint capacity, RICE scoring, customer-health scoring).
-- **Explicit skill tiers** (`TIERS.md` + `skill-tiers.json`): 46 Production-Ready, a curated Experimental set, Stable as default — surfaced in the README and the playground.
-- **Upgraded Skill Playground**: tier filter + badges and a "use this skill in another tool" copy panel.
-- **Repo hygiene**: `CHANGELOG.md`, `SKILL-AUTHORING-STANDARD.md`, refreshed `SECURITY.md`, `.gitignore`, and a Related Projects section.
+- **Explicit skill tiers** (`TIERS.md` + `skill-tiers.json`) and an **upgraded Skill Playground** (tier filter + "use in another tool" copy panel).
+- **Repo hygiene**: `CHANGELOG.md`, `SKILL-AUTHORING-STANDARD.md`, refreshed `SECURITY.md`, `.gitignore`, Related Projects.
+
+</details>
 
 <details>
 <summary><strong>Release history — v6.0.0 → v15.0.0</strong> (click to expand)</summary>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,9 @@ That said, security matters here in two specific ways: **skill file safety** and
 
 | Version | Supported |
 |---|---|
-| v16.x (latest) | ✅ Active |
-| v14.x – v15.x | ✅ Security fixes only |
-| < v14.0.0 | ❌ No longer supported |
+| v17.x (latest) | ✅ Active |
+| v15.x – v16.x | ✅ Security fixes only |
+| < v15.0.0 | ❌ No longer supported |
 
 Because skills are plain markdown, "support" means we review and correct any reported
 safety issue (prompt injection, unsafe instructions) in the listed versions.

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// pm-claude-skills — cross-platform installer for the skill library.
+// Works on Windows / macOS / Linux (pure Node, no bash, no git required).
+//
+//   npx pm-claude-skills add --agent codex
+//   npx pm-claude-skills add --agent claude        # skills + subagents + commands
+//   npx pm-claude-skills add --agent cursor        # .mdc rules into ./.cursor/rules
+//   npx pm-claude-skills list
+//
+// Flags for `add`:
+//   --agent <name>   claude | hermes | codex | openclaw | cursor   (required)
+//   --target <path>  override the default install directory
+//   --link           symlink instead of copy (native agents; falls back to copy)
+//   --dry-run        print what would happen without writing
+import { readdirSync, existsSync, mkdirSync, rmSync, cpSync, symlinkSync, copyFileSync, statSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+import { createRequire } from 'node:module';
+
+const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const VERSION = (() => {
+  try { return createRequire(import.meta.url)('../package.json').version; } catch { return '0.0.0'; }
+})();
+
+const NATIVE = new Set(['claude', 'hermes', 'codex', 'openclaw']);
+const defaultTarget = (agent) => ({
+  claude: join(homedir(), '.claude', 'skills'),
+  hermes: join(homedir(), '.hermes', 'skills'),
+  codex: join(homedir(), '.codex', 'skills'),
+  openclaw: join(homedir(), '.openclaw', 'skills'),
+  cursor: join(process.cwd(), '.cursor', 'rules'),
+}[agent]);
+
+function parse(argv) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--link') out.link = true;
+    else if (a === '--dry-run') out.dryRun = true;
+    else if (a === '--help' || a === '-h') out.help = true;
+    else if (a === '--version' || a === '-v') out.version = true;
+    else if (a.startsWith('--')) { out[a.slice(2)] = argv[i + 1]; i++; }
+    else out._.push(a);
+  }
+  return out;
+}
+
+function listMdc(dir) {
+  const out = [];
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) out.push(...listMdc(p));
+    else if (p.endsWith('.mdc')) out.push(p);
+  }
+  return out;
+}
+
+function placeDir(src, dest, { link, dryRun }) {
+  if (dryRun) { console.log(`  would install ${basename(src)} -> ${dest}`); return; }
+  rmSync(dest, { recursive: true, force: true });
+  if (link) {
+    try { symlinkSync(src, dest, 'dir'); return; }
+    catch { console.warn(`  (symlink unavailable, copying ${basename(src)})`); }
+  }
+  cpSync(src, dest, { recursive: true });
+}
+
+function add(opts) {
+  const agent = opts.agent;
+  if (!agent || !(NATIVE.has(agent) || agent === 'cursor')) {
+    console.error(`Error: --agent must be one of: claude, hermes, codex, openclaw, cursor.`);
+    process.exit(2);
+  }
+  const skillsDir = join(PKG_ROOT, 'skills');
+  if (!existsSync(skillsDir)) { console.error(`Error: bundled skills/ not found at ${skillsDir}.`); process.exit(1); }
+  const target = opts.target || defaultTarget(agent);
+  let count = 0;
+
+  console.log(`${opts.dryRun ? '[dry-run] ' : ''}Installing for '${agent}' into ${target}`);
+  if (!opts.dryRun) mkdirSync(target, { recursive: true });
+
+  if (agent === 'cursor') {
+    const cursorDir = join(PKG_ROOT, 'exports', 'cursor');
+    if (!existsSync(cursorDir)) { console.error(`Error: ${cursorDir} missing.`); process.exit(1); }
+    for (const mdc of listMdc(cursorDir).sort()) {
+      const dest = join(target, basename(mdc));
+      if (opts.dryRun) console.log(`  would install ${basename(mdc)} -> ${dest}`);
+      else copyFileSync(mdc, dest);
+      count++;
+    }
+  } else {
+    for (const name of readdirSync(skillsDir)) {
+      const src = join(skillsDir, name);
+      if (!existsSync(join(src, 'SKILL.md'))) continue;
+      placeDir(src, join(target, name), opts);
+      count++;
+    }
+    // Claude Code also gets subagents and slash commands.
+    if (agent === 'claude') {
+      const claudeRoot = dirname(target);
+      for (const kind of ['agents', 'commands']) {
+        const src = join(PKG_ROOT, kind);
+        if (!existsSync(src)) continue;
+        const dest = join(claudeRoot, kind);
+        if (!opts.dryRun) mkdirSync(dest, { recursive: true });
+        for (const f of readdirSync(src)) {
+          if (!f.endsWith('.md') || f === 'README.md') continue;
+          if (opts.dryRun) console.log(`  would install ${kind}/${f} -> ${join(dest, f)}`);
+          else copyFileSync(join(src, f), join(dest, f));
+          count++;
+        }
+      }
+    }
+  }
+
+  console.log(`\n${opts.dryRun ? 'Would install' : 'Installed'} ${count} item(s) for '${agent}'.`);
+  if (!opts.dryRun) {
+    console.log(agent === 'cursor'
+      ? `Cursor will pick up the rules in ${target} on its next session.`
+      : `Restart ${agent} — it auto-discovers SKILL.md skills in ${target} by their description.`);
+  }
+}
+
+function list() {
+  console.log('Supported agents and default targets:\n');
+  for (const a of ['claude', 'hermes', 'codex', 'openclaw', 'cursor']) {
+    console.log(`  ${a.padEnd(9)} ${defaultTarget(a)}`);
+  }
+  console.log('\nNative SKILL.md agents: claude, hermes, codex, openclaw (install skill folders).');
+  console.log('Claude also gets subagents + slash commands. Cursor installs .mdc rules.');
+}
+
+const HELP = `pm-claude-skills — install professional Agent Skills into any AI coding tool.
+
+Usage:
+  npx pm-claude-skills add --agent <claude|hermes|codex|openclaw|cursor> [--target <path>] [--link] [--dry-run]
+  npx pm-claude-skills list
+  npx pm-claude-skills --version
+
+Examples:
+  npx pm-claude-skills add --agent claude     # skills + subagents + commands
+  npx pm-claude-skills add --agent cursor     # .mdc rules into ./.cursor/rules
+  npx pm-claude-skills add --agent codex --link
+`;
+
+const opts = parse(process.argv.slice(2));
+const cmd = opts._[0];
+if (opts.version) console.log(VERSION);
+else if (opts.help || !cmd || cmd === 'help') console.log(HELP);
+else if (cmd === 'list') list();
+else if (cmd === 'add') add(opts);
+else { console.error(`Unknown command: ${cmd}\n`); console.log(HELP); process.exit(2); }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,45 @@
 {
   "name": "pm-claude-skills",
-  "version": "16.0.0",
-  "private": true,
+  "version": "17.0.0",
   "type": "module",
-  "description": "167 professional agent skills for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes — plus subagents, slash commands, and a multi-platform export pipeline.",
+  "description": "167 professional Agent Skills (SKILL.md) + subagents + slash commands for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes. Install into any AI coding tool with: npx pm-claude-skills add --agent <tool>.",
+  "keywords": [
+    "claude",
+    "claude-code",
+    "claude-skills",
+    "agent-skills",
+    "skill-md",
+    "chatgpt",
+    "gemini",
+    "cursor",
+    "codex",
+    "hermes-agent",
+    "ai-agents",
+    "subagents",
+    "slash-commands",
+    "prompt-engineering",
+    "product-management"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/mohitagw15856/pm-claude-skills",
   "repository": {
     "type": "git",
     "url": "https://github.com/mohitagw15856/pm-claude-skills.git"
   },
+  "bugs": {
+    "url": "https://github.com/mohitagw15856/pm-claude-skills/issues"
+  },
+  "author": "Mohit Aggarwal",
+  "bin": {
+    "pm-claude-skills": "bin/cli.mjs"
+  },
+  "files": [
+    "bin/",
+    "skills/",
+    "agents/",
+    "commands/",
+    "exports/"
+  ],
   "scripts": {
     "new-skill": "node scripts/new-skill.mjs",
     "skillcheck": "node scripts/skillcheck.mjs",


### PR DESCRIPTION
## The leapfrog: a cross-platform `npx` installer (v17.0.0)

`alirezarezvani/claude-skills` has **no npm CLI** — only shell installers. This adds one, which is both a differentiator and the **fix for the Windows gap** (the `bash <(curl …)` one-liners don't run in PowerShell).

```bash
npx pm-claude-skills add --agent claude     # skills + subagents + commands → ~/.claude/
npx pm-claude-skills add --agent codex      # OpenAI Codex
npx pm-claude-skills add --agent cursor     # .mdc rules → ./.cursor/rules
npx pm-claude-skills list
```

- **`bin/cli.mjs`** — pure Node (no bash, no git), so it works on **Windows/macOS/Linux**. Supports `--link`, `--target`, `--dry-run`, `list`, `--version`, `--help`. Symlink falls back to copy if the OS blocks it.
- **`package.json` is now publishable** — `bin` + `files` + keywords. Package name is **`pm-claude-skills`** because `pm-skills` is already taken on npm (verified: registry returns 200 for `pm-skills`, 404 for `pm-claude-skills`). `npm pack` ≈ 1.8 MB / 711 files.

## Version → v17.0.0
Since you've published v16.0.0, this work is **v17.0.0 (Agents, Commands & the npx CLI)** — it bundles everything merged since v16 (subagents, slash commands, SkillCheck, Cursor exports, installers, scaffolder) plus the new CLI.
- README badge + "What's New" (v16 moved into collapsed history), `CHANGELOG.md` promoted `Unreleased → [17.0.0]`, `SECURITY.md` table, and the install sections now **lead with `npx`** and flag the Windows/PowerShell path.

## Verification
- CLI tested: `claude` installs 182 items (172 skills + 4 agents + 6 commands), `cursor` 172 `.mdc`, `--link` symlinks, bad-agent exits 2, `list`/`--version`/`--help` work, dry-run counts correct.
- `npm pack --dry-run` includes `bin/cli.mjs` and the content.
- SkillCheck 0 errors; exports + `web/skills.json` in sync; version strings consistent; no stray "v16 latest".

> ⚠️ To make `npx pm-claude-skills` actually resolve, you'll need to `npm publish` the package once (from `main` after this merges). I can't publish from here (no npm auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_