### PR TITLE
Automated npm publish via GitHub Actions (no local npm needed)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,50 @@
+name: Publish to npm
+
+# Publishes the package to npm when you publish a GitHub Release (or run this
+# workflow manually). No local npm needed — set one repo secret, NPM_TOKEN, and
+# every release ships `npx pm-claude-skills` to the world.
+#
+# One-time setup:
+#   1. Create a free npm account at https://www.npmjs.com/signup
+#   2. Profile -> Access Tokens -> Generate New Token -> "Automation"
+#   3. In this repo: Settings -> Secrets and variables -> Actions -> New repository
+#      secret named NPM_TOKEN with that token.
+# Then: publish a GitHub Release tagged vX.Y.Z (matching package.json version).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write   # enables npm provenance (a verified "published from this repo" badge)
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify release tag matches package.json version
+        if: github.event_name == 'release'
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          echo "release tag: $TAG | package.json: $PKG"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Release tag ($TAG) does not match package.json version ($PKG). Bump package.json or fix the tag."
+            exit 1
+          fi
+
+      - name: Publish to npm (public, with provenance)
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+- **Automated npm publishing** — `.github/workflows/npm-publish.yml` publishes the package
+  to npm (with provenance) when a GitHub Release is published. Requires a one-time
+  `NPM_TOKEN` repo secret; no local npm needed.
 
 ## [17.0.0] — Agents, Commands & the npx CLI — 2026-06-17
 


### PR DESCRIPTION
You asked me to `npm publish`. I **can't** do that directly — publishing is bound to your npm account (needs your auth/2FA), this sandbox is ephemeral, and npm publishes are effectively permanent. So instead, here's the thing that actually solves *"I don't have npm locally"*: **publish from CI.**

## What this adds
`.github/workflows/npm-publish.yml` — when you **publish a GitHub Release**, CI runs `npm publish` for you:
- Verifies the release tag matches `package.json` version (prevents shipping the wrong version).
- Publishes **public, with provenance** (`id-token: write`) — npm shows a verified "published from this repo" badge, which is good for trust/credibility.
- Manual `workflow_dispatch` trigger too, if you want to publish without a release.

## Your one-time setup (≈3 minutes, no npm install needed)
1. Create a free npm account → https://www.npmjs.com/signup
2. npm → **Access Tokens** → **Generate New Token** → type **Automation**.
3. This repo → **Settings → Secrets and variables → Actions → New repository secret**, name it **`NPM_TOKEN`**, paste the token.
4. Publish the **v17.0.0** GitHub Release (tag `v17.0.0`). The workflow runs and `pm-claude-skills` goes live → `npx pm-claude-skills add --agent …` works for everyone.

(After that, every future release auto-publishes — just bump `package.json` to match the tag.)

## Readiness verified
Name `pm-claude-skills` is still available (registry 404), package is `17.0.0`, `bin`/`files` correct, not private, LICENSE+README+shebang present, `npm pack` ≈ 1.8 MB / 711 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_