### PR TITLE
Fix npm-publish tag check to accept capital-V tags

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Verify release tag matches package.json version
         if: github.event_name == 'release'
         run: |
-          TAG="${GITHUB_REF_NAME#v}"
+          TAG="${GITHUB_REF_NAME#[vV]}"   # strip a leading v or V (v17.0.0 / V17.0.0)
           PKG="$(node -p "require('./package.json').version")"
           echo "release tag: $TAG | package.json: $PKG"
           if [ "$TAG" != "$PKG" ]; then


### PR DESCRIPTION
Fixes the publish failure you hit:

```
release tag: V17.0.0 | package.json: 17.0.0
Error: Release tag (V17.0.0) does not match package.json version (17.0.0).
```

The tag check stripped only a lowercase `v`, so a `V17.0.0` tag failed. Now it strips a leading **`v` or `V`** (`${GITHUB_REF_NAME#[vV]}`), so `v17.0.0`, `V17.0.0`, and `17.0.0` all normalise to `17.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_