### PR TITLE
Dogfood the Action + bump to v20.0.0 (Agentic Tooling)

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -1,0 +1,71 @@
+name: Auto PR description
+
+# Dogfoods our own Action: when a PR is opened with an empty body, run the
+# pr-description-writer skill on the diff and fill it in. A living demo of
+# `uses: ./action`. Requires the ANTHROPIC_API_KEY repo secret; skips quietly
+# without it (and on forks, which can't read secrets).
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  describe:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    steps:
+      - name: Check for API key and an empty PR body
+        id: gate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const hasKey = !!process.env.ANTHROPIC_API_KEY;
+            const body = (context.payload.pull_request.body || '').trim();
+            if (!hasKey) core.info('ANTHROPIC_API_KEY not set — skipping.');
+            if (body) core.info('PR already has a description — skipping.');
+            core.setOutput('go', String(hasKey && !body));
+
+      - name: Checkout
+        if: steps.gate.outputs.go == 'true'
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Collect the diff
+        if: steps.gate.outputs.go == 'true'
+        id: diff
+        run: |
+          {
+            echo "text<<DIFF_EOF"
+            echo "Title: ${{ github.event.pull_request.title }}"
+            echo "Commits:"; git log --oneline origin/${{ github.base_ref }}..HEAD | head -30
+            echo; echo "Changed files:"; git diff --stat origin/${{ github.base_ref }}...HEAD | tail -40
+            echo "DIFF_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Write the PR description with the skill
+        if: steps.gate.outputs.go == 'true'
+        id: skill
+        uses: ./action
+        with:
+          skill: pr-description-writer
+          input: ${{ steps.diff.outputs.text }}
+          api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+
+      - name: Update the PR body
+        if: steps.gate.outputs.go == 'true'
+        uses: actions/github-script@v7
+        env:
+          BODY: ${{ steps.skill.outputs.result }}
+        with:
+          script: |
+            await github.rest.pulls.update({
+              owner: context.repo.owner, repo: context.repo.repo,
+              pull_number: context.issue.number,
+              body: process.env.BODY + '\n\n<sub>✍️ Drafted by the pm-claude-skills GitHub Action (pr-description-writer).</sub>',
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
 
 ## [Unreleased]
 
+_Nothing yet._
+
+## [20.0.0] — Agentic Tooling — 2026-06-18
+
 ### Added
+- **Dogfooded Action** — `.github/workflows/pr-description.yml` uses our own GitHub Action
+  (`uses: ./action`) to auto-write this repo's PR descriptions when a PR opens with an
+  empty body (skips quietly without the `ANTHROPIC_API_KEY` secret and on forks).
 - **GitHub Action** ([`action/`](action/)) — run any skill in CI: `uses:
   mohitagw15856/pm-claude-skills/action@main` to auto-write PR descriptions,
   changelogs, release notes, or code-review checklists. Composite action +
@@ -211,7 +218,8 @@ Earlier releases (v1.0.0 – v5.0.0) predate this changelog. See the
 [article series](README.md#-the-article-series) for the full history of how the
 library grew from the first PM toolkit to 100+ skills.
 
-[Unreleased]: https://github.com/mohitagw15856/pm-claude-skills/compare/v19.0.0...HEAD
+[Unreleased]: https://github.com/mohitagw15856/pm-claude-skills/compare/v20.0.0...HEAD
+[20.0.0]: https://github.com/mohitagw15856/pm-claude-skills/compare/v19.0.0...v20.0.0
 [19.0.0]: https://github.com/mohitagw15856/pm-claude-skills/compare/v18.0.0...v19.0.0
 [18.0.0]: https://github.com/mohitagw15856/pm-claude-skills/compare/v17.0.0...v18.0.0
 [17.0.0]: https://github.com/mohitagw15856/pm-claude-skills/compare/v16.0.0...v17.0.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Platforms](https://img.shields.io/badge/works%20with-Claude%20%7C%20ChatGPT%20%7C%20Gemini%20%7C%20Cursor%20%7C%20Codex%20%7C%20Hermes-8A2BE2)](#-works-with--cross-tool-compatibility)
 [![SkillCheck](https://img.shields.io/github/actions/workflow/status/mohitagw15856/pm-claude-skills/skillcheck.yml?branch=main&label=SkillCheck)](.github/workflows/skillcheck.yml)
 [![Security Audit](https://img.shields.io/github/actions/workflow/status/mohitagw15856/pm-claude-skills/skill-audit.yml?branch=main&label=security%20audit)](.github/workflows/skill-audit.yml)
-[![Version](https://img.shields.io/badge/version-19.0.0-brightgreen)](https://github.com/mohitagw15856/pm-claude-skills/releases)
+[![Version](https://img.shields.io/badge/version-20.0.0-brightgreen)](https://github.com/mohitagw15856/pm-claude-skills/releases)
 [![Install](https://img.shields.io/badge/Install%20in%20Claude%20Code-2%20minutes-orange)](https://github.com/mohitagw15856/pm-claude-skills#-quick-install-2-minutes)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/sponsor-❤️-ff69b4)](https://github.com/sponsors/mohitagw15856)
@@ -22,7 +22,7 @@
 
 A community-built library of professional skills for every field — product management, engineering, customer success, marketing, social media, writers, design, legal, finance, HR, sales, operations, research, and more. Each skill is a structured `SKILL.md` file that teaches an AI assistant how to produce professional-grade outputs for your workflows. Skills run natively in **Claude Code** and **Hermes Agent** (same open `SKILL.md` standard), and ship as ready-to-paste exports for **ChatGPT** and **Gemini** — see [Works With](#-works-with--cross-tool-compatibility).
 
-**🆕 Latest release (v19.0.0 — Security Auditor, Personas & Catalog):** a CI **Skill Security Auditor** that flags prompt-injection / unsafe code in any skill, **4 personas** (output-styles), an [orchestration guide](ORCHESTRATION.md), a server-rendered **skill catalog**, and a public [roadmap](ROADMAP.md). See the [changelog](#-changelog).
+**🆕 Latest release (v20.0.0 — Agentic Tooling):** run any skill in CI with the new **[GitHub Action](action/)**, turn your docs into a skill with **`npx pm-claude-skills generate`**, and compare skills across models on the **[Skill Leaderboard](https://mohitagw15856.github.io/pm-claude-skills/leaderboard.html)** (LLM-judge evals). See the [changelog](#-changelog).
 
 <!-- DEMO: replace web/docs-assets/playground.png below with web/docs-assets/playground-demo.gif
      once recorded (see web/docs-assets/README.md for how). The link goes to the live app. -->
@@ -403,15 +403,21 @@ More templates will follow. If you want to contribute one, see the [template con
 
 The highlights are below. For the structured, [Keep a Changelog](https://keepachangelog.com/)-format history, see **[CHANGELOG.md](CHANGELOG.md)**.
 
-### 🆕 What's New in v19.0.0 — Security Auditor, Personas & Catalog
+### 🆕 What's New in v20.0.0 — Agentic Tooling
 
-Trust, more content types, and discoverability:
+The library starts *doing* the work, not just describing it:
 
-- **Skill Security Auditor** — `scripts/skill-audit.mjs` scans every skill (and its scripts) for prompt injection, data exfiltration, unsafe code, secrets, and hidden text; **HIGH findings fail CI**. New `security audit` badge + a `skill-security-auditor` skill.
-- **Personas** — 4 Claude Code output-styles (Startup CTO, Growth Marketer, Solo Founder, Product Leader) in [`output-styles/`](output-styles/).
-- **Orchestration guide** ([`ORCHESTRATION.md`](ORCHESTRATION.md)) — Skill Chain, Multi-Agent Handoff, Domain Deep-Dive, Solo Sprint.
-- **Static skill catalog** — a server-rendered, SEO-indexable catalog of every skill (linked from the README + Playground).
-- **Public roadmap** ([`ROADMAP.md`](ROADMAP.md)) with now/next/later + good first issues.
+- **GitHub Action** ([`action/`](action/)) — run any skill in a repo's CI (auto PR descriptions, changelogs, release notes, reviews). `uses: mohitagw15856/pm-claude-skills/action@main`. We dogfood it to write this repo's own PR descriptions.
+- **`generate` command** — `npx pm-claude-skills generate --from <url|file>` turns your docs into a standard-compliant `SKILL.md`.
+- **Skill evals + Leaderboard** — LLM-as-judge scoring of skills across models, rendered as a public [leaderboard](https://mohitagw15856.github.io/pm-claude-skills/leaderboard.html).
+
+<details>
+<summary><strong>v19.0.0 — Security Auditor, Personas & Catalog</strong> (click to expand)</summary>
+
+- **Skill Security Auditor** — scans every skill (and its scripts) for prompt injection, exfiltration, unsafe code, secrets, hidden text; HIGH fails CI. Plus a `skill-security-auditor` skill.
+- **4 personas** (output-styles), an [orchestration guide](ORCHESTRATION.md), a server-rendered **skill catalog**, and a public [roadmap](ROADMAP.md).
+
+</details>
 
 <details>
 <summary><strong>v18.0.0 — Windsurf, Aider & an MCP Server</strong> (click to expand)</summary>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,9 +10,9 @@ That said, security matters here in two specific ways: **skill file safety** and
 
 | Version | Supported |
 |---|---|
-| v19.x (latest) | ✅ Active |
-| v17.x – v18.x | ✅ Security fixes only |
-| < v17.0.0 | ❌ No longer supported |
+| v20.x (latest) | ✅ Active |
+| v18.x – v19.x | ✅ Security fixes only |
+| < v18.0.0 | ❌ No longer supported |
 
 Because skills are plain markdown, "support" means we review and correct any reported
 safety issue (prompt injection, unsafe instructions) in the listed versions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-claude-skills",
-  "version": "19.0.0",
+  "version": "20.0.0",
   "type": "module",
   "description": "167 professional Agent Skills (SKILL.md) + subagents + slash commands for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes. Install into any AI coding tool with: npx pm-claude-skills add --agent <tool>.",
   "keywords": [


### PR DESCRIPTION
## Dogfood the GitHub Action
`.github/workflows/pr-description.yml` uses **our own Action** (`uses: ./action`) to auto-write this repo's PR descriptions when a PR opens with an empty body — a living demo. It skips quietly without the `ANTHROPIC_API_KEY` secret and on forks (which can't read secrets), and won't clobber a description you've already written.

## v20.0.0 — Agentic Tooling
Bundles the GitHub Action, `generate` command, and evals/leaderboard (already on `main`) for npm.
- `package.json` → **20.0.0**; README badge + "What's New in v20.0.0" (v19 collapsed) + latest-release line; `CHANGELOG` `[Unreleased]` → `[20.0.0]`; `SECURITY` table.

Verified: version consistent, exports (173×5) + `skills.json` in sync, SkillCheck 0 errors, security audit 0 high, `npm pack` = 20.0.0, dogfood workflow YAML sane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_