### PR TITLE
fix: add installation path safety and robust frontmatter parsing

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -13,7 +13,7 @@
 //   --link           symlink instead of copy (native agents; falls back to copy)
 //   --dry-run        print what would happen without writing
 import { readdirSync, existsSync, mkdirSync, rmSync, cpSync, symlinkSync, copyFileSync, statSync } from 'node:fs';
-import { join, dirname, basename } from 'node:path';
+import { join, dirname, basename, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 import { createRequire } from 'node:module';
@@ -78,7 +78,15 @@ function add(opts) {
   }
   const skillsDir = join(PKG_ROOT, 'skills');
   if (!existsSync(skillsDir)) { console.error(`Error: bundled skills/ not found at ${skillsDir}.`); process.exit(1); }
-  const target = opts.target || defaultTarget(agent);
+  const target = resolve(opts.target || defaultTarget(agent));
+
+  // Prevent installation into critical system directories
+  const criticalPaths = ['/', '/usr', '/bin', '/etc', '/var', '/root', '/boot', '/proc', '/sys', '/dev'];
+  if (criticalPaths.includes(target)) {
+    console.error(`Error: Cannot install into a system-critical directory: ${target}`);
+    process.exit(1);
+  }
+
   let count = 0;
 
   console.log(`${opts.dryRun ? '[dry-run] ' : ''}Installing for '${agent}' into ${target}`);

--- a/scripts/skillcheck.mjs
+++ b/scripts/skillcheck.mjs
@@ -22,10 +22,12 @@ const strict = args.includes('--strict');
 const asJson = args.includes('--json');
 
 function parseFrontmatter(text) {
-  const m = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  // Improved regex: supports optional leading whitespace, case-insensitive frontmatter delimiters,
+  // and CRLF/LF line endings.
+  const m = text.match(/^\s*---\r?\n([\s\S]*?)\r?\n\s*---\r?\n?([\s\S]*)$/);
   if (!m) return { meta: null, body: text };
   const meta = {};
-  for (const line of m[1].split('\n')) {
+  for (const line of m[1].split(/\r?\n/)) {
     const kv = line.match(/^(\w[\w-]*):\s*(.*)$/);
     if (kv) {
       let v = kv[2].trim();


### PR DESCRIPTION
Prevents potential system file corruption by adding safety checks to the installation target path in the CLI, rejecting system-critical directories like root, /usr, or /etc. Additionally, improves the skill validation script's YAML frontmatter parser by allowing leading whitespace and supporting CRLF line endings, preventing false negatives during skill auditing.