### PR TITLE
feat: convert npm users into GitHub stargazers (CLI nudge + README CTA + funding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 [![License](https://img.shields.io/badge/license-MIT-lightgrey)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/sponsor-❤️-ff69b4)](https://github.com/sponsors/mohitagw15856)
 
+### ⭐ If this saves you time, [star the repo](https://github.com/mohitagw15856/pm-claude-skills) — it's the #1 way to help others find it.
+
 > **PM stands for Professional, not just Product Management.**
 > 167 professional skills + 4 agent templates across 26 bundles covering 18 professions. Built for Claude Code — and now portable to ChatGPT, Gemini, and Hermes Agent. Built by a PM, used by everyone.
 

--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -19,6 +19,7 @@ import { homedir } from 'node:os';
 import { createRequire } from 'node:module';
 
 const PKG_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const STAR = '⭐ Find this useful? Star the repo: https://github.com/mohitagw15856/pm-claude-skills';
 const VERSION = (() => {
   try { return createRequire(import.meta.url)('../package.json').version; } catch { return '0.0.0'; }
 })();
@@ -128,6 +129,7 @@ function add(opts) {
       aider: `Load any of them with:  aider --read ${join(target, '<skill>.md')}`,
     }[agent] || `Restart ${agent} — it auto-discovers SKILL.md skills in ${target} by their description.`;
     console.log(note);
+    console.log(`\n${STAR}`);
   }
 }
 
@@ -155,6 +157,8 @@ Examples:
   npx pm-claude-skills add --agent codex --link
 
   npx pm-claude-skills generate --from <url|file>   # turn your docs into a SKILL.md (needs ANTHROPIC_API_KEY)
+
+${STAR}
 `;
 
 const opts = parse(process.argv.slice(2));

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
   "bugs": {
     "url": "https://github.com/mohitagw15856/pm-claude-skills/issues"
   },
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/mohitagw15856/pm-claude-skills"
+  },
   "author": "Mohit Aggarwal",
   "bin": {
     "pm-claude-skills": "bin/cli.mjs",


### PR DESCRIPTION
With ~125 npm installs/week, this adds three tasteful, non-spammy ways to turn package users into GitHub stars:

1. **CLI star prompt** — after a successful `npx pm-claude-skills add`, and in `--help`, the CLI prints:
   `⭐ Find this useful? Star the repo: https://github.com/...`
   (Gated behind real installs — not shown on `--dry-run`. No `postinstall` hook, which would be an anti-pattern.)
2. **README star CTA** — a prominent one-liner below the badges. npm renders the README on the package page, so this reaches people who never visit GitHub.
3. **`funding` field** in `package.json` — npm surfaces a Fund/Sponsor link from this.

Note: the README and `funding` changes only appear on the npm package page **after the next publish**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_