### PR TITLE
feat: star CTA in CLI list + MCP banner

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -141,6 +141,7 @@ function list() {
   console.log('\nNative SKILL.md agents: claude, hermes, codex, openclaw (install skill folders).');
   console.log('Claude also gets subagents + slash commands. Cursor/Windsurf install rule files;');
   console.log('Aider installs conventions you load with "aider --read".');
+  console.log(`\n${STAR}`);
 }
 
 const HELP = `pm-claude-skills — install professional Agent Skills into any AI coding tool.

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -166,6 +166,7 @@ function handle(msg) {
 }
 
 process.stderr.write(`[${SERVER_NAME}] MCP server ready — ${SKILLS.length} skills, ${TOOLS.length} tools.\n`);
+process.stderr.write(`[${SERVER_NAME}] ⭐ Star the repo: https://github.com/mohitagw15856/pm-claude-skills\n`);
 const rl = createInterface({ input: process.stdin });
 rl.on('line', (line) => {
   const s = line.trim();


### PR DESCRIPTION
Follow-up to #49 — two more low-key star touchpoints:

- **`npx pm-claude-skills list`** now ends with the star CTA.
- **MCP server** prints the star line in its stderr startup banner (stderr is safe — it never corrupts the JSON-RPC protocol stream on stdout).

No behavior change beyond the extra log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_