### PR TITLE
release: v20.1.0 — star nudges & eval hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
 
 ## [Unreleased]
 
+## [20.1.0] — Star Nudges & Eval Hardening — 2026-06-18
+
+### Added
+- **Star the repo, from anywhere you use it.** Tasteful, non-spammy calls-to-action that turn
+  npm/CLI users into stargazers — no `postinstall` hook: a prompt after a successful
+  `npx pm-claude-skills add`, in `--help`, in `list`, in the MCP server's startup banner, a
+  CTA below the README badges (npm renders it on the package page), and a `funding` field in
+  `package.json` so npm shows a Fund/Sponsor link.
+- **One-click leaderboard updates in CI** — `.github/workflows/eval-leaderboard.yml`
+  ("Update Skill Leaderboard") runs the evals with the `ANTHROPIC_API_KEY` secret, commits
+  `evals/results.json`, and the Pages deploy re-renders the public leaderboard with real
+  numbers — no local key needed. The deploy workflow now also triggers on
+  `evals/results.json`.
+
 ### Changed
 - **Leaderboard workflow opens a PR** instead of pushing to `main` (which the branch
   ruleset blocks). After it runs, merge the auto-created results PR to publish real numbers.
@@ -16,13 +30,6 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
   and limited retries (429/5xx/timeout); the eval harness runs cases concurrently
   (default 4). The leaderboard workflow has a 20-minute job timeout. A 24-call run that
   was sequential now finishes in a few minutes and can't stall a job indefinitely.
-
-### Added
-- **One-click leaderboard updates in CI** — `.github/workflows/eval-leaderboard.yml`
-  ("Update Skill Leaderboard") runs the evals with the `ANTHROPIC_API_KEY` secret, commits
-  `evals/results.json`, and the Pages deploy re-renders the public leaderboard with real
-  numbers — no local key needed. The deploy workflow now also triggers on
-  `evals/results.json`.
 
 ## [20.0.0] — Agentic Tooling — 2026-06-18
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Platforms](https://img.shields.io/badge/works%20with-Claude%20%7C%20ChatGPT%20%7C%20Gemini%20%7C%20Cursor%20%7C%20Codex%20%7C%20Hermes-8A2BE2)](#-works-with--cross-tool-compatibility)
 [![SkillCheck](https://img.shields.io/github/actions/workflow/status/mohitagw15856/pm-claude-skills/skillcheck.yml?branch=main&label=SkillCheck)](.github/workflows/skillcheck.yml)
 [![Security Audit](https://img.shields.io/github/actions/workflow/status/mohitagw15856/pm-claude-skills/skill-audit.yml?branch=main&label=security%20audit)](.github/workflows/skill-audit.yml)
-[![Version](https://img.shields.io/badge/version-20.0.0-brightgreen)](https://github.com/mohitagw15856/pm-claude-skills/releases)
+[![Version](https://img.shields.io/badge/version-20.1.0-brightgreen)](https://github.com/mohitagw15856/pm-claude-skills/releases)
 [![Install](https://img.shields.io/badge/Install%20in%20Claude%20Code-2%20minutes-orange)](https://github.com/mohitagw15856/pm-claude-skills#-quick-install-2-minutes)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/sponsor-❤️-ff69b4)](https://github.com/sponsors/mohitagw15856)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-claude-skills",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "type": "module",
   "description": "167 professional Agent Skills (SKILL.md) + subagents + slash commands for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes. Install into any AI coding tool with: npx pm-claude-skills add --agent <tool>.",
   "keywords": [


### PR DESCRIPTION
Prep the **v20.1.0** release so the star CTAs (and the prior unreleased eval work) ship to npm.

### What's in 20.1.0
- **Star nudges** (#49, #51): CLI `add`/`--help`/`list`, MCP banner, README CTA, `package.json` `funding` field.
- **CI leaderboard + PR-based results flow + faster/hang-proof evals** (previously in `[Unreleased]`).

### Changes here
- `package.json`: `20.0.0` → `20.1.0`
- `CHANGELOG.md`: new `[20.1.0]` section folding in the above
- `README.md`: version badge → 20.1.0

`npm run check` passes (0 errors, exports up to date).

### To actually publish (your step — needs npm auth)
After this merges, **create a GitHub Release tagged `v20.1.0`** (target `main`). That fires `npm-publish.yml`, which verifies the tag matches `package.json` and runs `npm publish`. The README + `funding` link then appear on the npm package page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_