### PR TITLE
release: finalize v20.1.0 changelog/README + harden check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
 
 ## [Unreleased]
 
-## [20.1.0] — Star Nudges & Eval Hardening — 2026-06-18
+## [20.1.0] — Star Nudges, Community PRs & Hardening — 2026-06-18
 
 ### Added
 - **Star the repo, from anywhere you use it.** Tasteful, non-spammy calls-to-action that turn
@@ -17,6 +17,12 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
   `npx pm-claude-skills add`, in `--help`, in `list`, in the MCP server's startup banner, a
   CTA below the README badges (npm renders it on the package page), and a `funding` field in
   `package.json` so npm shows a Fund/Sponsor link.
+- **New skill: YouTube Script Writer** (experimental) — retention-optimized video scripts with
+  3 title/thumbnail concepts, 3 hook variations, a video/audio cue script table, and SEO
+  metadata. Thanks @prajwal-28 (#50). Library is now **174 skills**.
+- **Feature-prioritisation helper script** — a dependency-free (stdlib-only) Python helper that
+  computes RICE/ICE rankings from JSON/CSV/stdin, so scoring is consistent across sessions.
+  Thanks @zeotrix (#48, closes #39).
 - **One-click leaderboard updates in CI** — `.github/workflows/eval-leaderboard.yml`
   ("Update Skill Leaderboard") runs the evals with the `ANTHROPIC_API_KEY` secret, commits
   `evals/results.json`, and the Pages deploy re-renders the public leaderboard with real
@@ -24,12 +30,21 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
   `evals/results.json`.
 
 ### Changed
+- **Safer installs** — the CLI now resolves the install target and refuses system-critical
+  directories (`/`, `/usr`, `/etc`, `/root`, …) so a mistyped `--target` can't clobber the
+  system. Thanks @MatrixNeoKozak (#47).
 - **Leaderboard workflow opens a PR** instead of pushing to `main` (which the branch
   ruleset blocks). After it runs, merge the auto-created results PR to publish real numbers.
 - **Faster, hang-proof evals.** The Anthropic client now has a per-request timeout (120s)
   and limited retries (429/5xx/timeout); the eval harness runs cases concurrently
   (default 4). The leaderboard workflow has a 20-minute job timeout. A 24-call run that
   was sequential now finishes in a few minutes and can't stall a job indefinitely.
+
+### Fixed
+- **`skillcheck` frontmatter parser** tolerates leading whitespace and CRLF/LF line endings, so
+  skills authored on Windows no longer produce false negatives. Thanks @MatrixNeoKozak (#47).
+- **`npm run check` now guards `web/skills.json`** — it rebuilds the file and fails on any drift,
+  so a stale playground index can't pass locally and then break CI.
 
 ## [20.0.0] — Agentic Tooling — 2026-06-18
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 A community-built library of professional skills for every field — product management, engineering, customer success, marketing, social media, writers, design, legal, finance, HR, sales, operations, research, and more. Each skill is a structured `SKILL.md` file that teaches an AI assistant how to produce professional-grade outputs for your workflows. Skills run natively in **Claude Code** and **Hermes Agent** (same open `SKILL.md` standard), and ship as ready-to-paste exports for **ChatGPT** and **Gemini** — see [Works With](#-works-with--cross-tool-compatibility).
 
-**🆕 Latest release (v20.1.0 — Star Nudges & Eval Hardening):** run any skill in CI with the **[GitHub Action](action/)**, turn your docs into a skill with **`npx pm-claude-skills generate`**, compare skills across models on the **[Skill Leaderboard](https://mohitagw15856.github.io/pm-claude-skills/leaderboard.html)** (now one-click in CI), and — if it saves you time — ⭐ the repo. See the [changelog](#-changelog).
+**🆕 Latest release (v20.1.0 — Star Nudges, Community PRs & Hardening):** a new **YouTube Script Writer** skill (174 total), a stdlib **feature-prioritisation** helper, safer installs, one-click leaderboard updates in CI, and star CTAs across the CLI/README/npm. See the [changelog](#-changelog).
 
 <!-- DEMO: replace web/docs-assets/playground.png below with web/docs-assets/playground-demo.gif
      once recorded (see web/docs-assets/README.md for how). The link goes to the live app. -->
@@ -405,9 +405,12 @@ More templates will follow. If you want to contribute one, see the [template con
 
 The highlights are below. For the structured, [Keep a Changelog](https://keepachangelog.com/)-format history, see **[CHANGELOG.md](CHANGELOG.md)**.
 
-### 🆕 What's New in v20.1.0 — Star Nudges & Eval Hardening
+### 🆕 What's New in v20.1.0 — Star Nudges, Community PRs & Hardening
 
 - **Star the repo, from anywhere you use it** — tasteful, non-spammy CTAs (no `postinstall`): after a successful `npx pm-claude-skills add`, in `--help`, in `list`, in the MCP server banner, below the README badges, and a `funding` link on npm.
+- **New skill: YouTube Script Writer** (experimental) — retention-optimized video scripts with hook variations, a video/audio cue table, and SEO metadata. Thanks @prajwal-28 (#50). **Now 174 skills.**
+- **Feature-prioritisation helper** — a dependency-free Python script that computes RICE/ICE rankings consistently across sessions. Thanks @zeotrix (#48).
+- **Safer installs + robust parsing** — the CLI refuses system-critical install targets, and `skillcheck` tolerates CRLF/whitespace in frontmatter. Thanks @MatrixNeoKozak (#47).
 - **One-click leaderboard in CI** — the "Update Skill Leaderboard" workflow runs the evals with your `ANTHROPIC_API_KEY` secret and opens a results PR; merge it to publish real numbers.
 - **Faster, hang-proof evals** — per-request timeout + retries in the API client and concurrent eval runs, so a CI run finishes in minutes and can't stall.
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "skillcheck": "node scripts/skillcheck.mjs",
     "build:exports": "node scripts/build-exports.mjs",
     "build:web": "node web/build-skills.mjs",
-    "check": "node scripts/skillcheck.mjs && node scripts/build-exports.mjs --check"
+    "check": "node scripts/skillcheck.mjs && node scripts/build-exports.mjs --check && node web/build-skills.mjs && git diff --exit-code -- web/skills.json"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Finalizes the **v20.1.0** changelog/README to include the three merged community PRs and the new skill, and hardens the local check.

### Changes
- **`CHANGELOG.md` / `README.md`** — the v20.1.0 section now covers the YouTube Script Writer skill (#50), the feature-prioritisation helper (#48), and safer installs + robust frontmatter parsing (#47), and reflects the **174-skill** total. Contributors credited.
- **`package.json`** — `npm run check` now also rebuilds `web/skills.json` and fails on drift (`git diff --exit-code`), closing the gap that let a stale playground index pass locally and break `check-generated` CI.

### Verification
- `npm run check` → 174 skills, 0 errors, exports up to date, `web/skills.json` not stale (exit 0).
- `package.json` is valid JSON; version stays 20.1.0 (still unreleased on npm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_