### PR TITLE
fix(marketplace): add missing pm-social plugin.json manifest

### DIFF
--- a/plugins/pm-social/.claude-plugin/plugin.json
+++ b/plugins/pm-social/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
+  "name": "pm-social",
+  "version": "1.0.0",
+  "description": "Social Media skills: Social Media Audit, Influencer Brief, Community Management Playbook, Social Ad Campaign, Viral Content Framework. Score your social presence, brief influencer partnerships, manage communities at scale, plan paid social campaigns with full ad copy, and build a repeatable system for shareable content.",
+  "author": {
+    "name": "Mohit Aggarwal",
+    "email": "mohit15856@gmail.com"
+  },
+  "homepage": "https://github.com/mohitagw15856/pm-claude-skills",
+  "license": "MIT",
+  "keywords": ["social-media", "influencer-marketing", "community-management", "paid-social", "content-strategy", "viral-content", "social-audit"]
+}


### PR DESCRIPTION
`pm-social` was the last bundle without a `.claude-plugin/plugin.json` manifest — a latent gap that can block clean plugin installation (every other bundle has one).

### Change
- Adds `plugins/pm-social/.claude-plugin/plugin.json`, matching its `marketplace.json` entry (version 1.0.0, same description + sensible keywords).

Independent of PR #23 (pm-social is an existing, maintainer-created bundle).

### Verification
- JSON valid; **all 25 bundles now have a manifest**.
- `npm run check` → 174 skills, 0 errors, exports in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px

---
_Generated by [Claude Code](https://claude.ai/code/session_016JWn5jRD5tcEFKrubjQ6Px)_