### PR TITLE
docs(readme): add integrations badge + hero line (n8n, Lovable, Obsidian)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 [![Commands](https://img.shields.io/badge/slash%20commands-6-blueviolet)](commands/)
 [![Personas](https://img.shields.io/badge/personas-4-blueviolet)](output-styles/)
 [![Platforms](https://img.shields.io/badge/works%20with-Claude%20%7C%20ChatGPT%20%7C%20Gemini%20%7C%20Cursor%20%7C%20Codex%20%7C%20Hermes-8A2BE2)](#-works-with--cross-tool-compatibility)
+[![Integrations](https://img.shields.io/badge/integrates%20with-n8n%20%C2%B7%20Lovable%20%C2%B7%20Obsidian-0E9F6E)](connectors/)
 [![SkillCheck](https://img.shields.io/github/actions/workflow/status/mohitagw15856/pm-claude-skills/skillcheck.yml?branch=main&label=SkillCheck)](.github/workflows/skillcheck.yml)
 [![Security Audit](https://img.shields.io/github/actions/workflow/status/mohitagw15856/pm-claude-skills/skill-audit.yml?branch=main&label=security%20audit)](.github/workflows/skill-audit.yml)
 [![Version](https://img.shields.io/github/v/release/mohitagw15856/pm-claude-skills?label=version&color=brightgreen)](https://github.com/mohitagw15856/pm-claude-skills/releases)
@@ -34,6 +35,8 @@
 </p>
 
 > **Generic AI gives you filler. These give you the structure a senior pro actually uses** — PRDs, exec updates, launch plans, postmortems — as open-source `SKILL.md` files. Across **21 professions**, not just product management. One source, every AI tool.
+
+> **🆕 Now plugs into your stack** — automate skills in **[n8n](connectors/n8n.md)**, build apps on **[Lovable](connectors/lovable.md)**, and run them in your **[Obsidian](connectors/obsidian.md)** vault, all via a read-only **[REST API](mcp-remote/#rest-api-for-n8n-lovable-make-any-http-tool)** on the hosted Worker.
 
 ### ⭐ If this saves you time, [star the repo](https://github.com/mohitagw15856/pm-claude-skills) — it's the #1 way to help others find it.
 


### PR DESCRIPTION
Surfaces the new integration reach in the README hero — kept honest by separating "native skill runners" from "integration surfaces."

## Changes
- **Integrations badge** under the Platforms badge: `integrates with — n8n · Lovable · Obsidian` → links to `connectors/`.
- **Hero line** under the main tagline:
  > 🆕 Now plugs into your stack — automate skills in n8n, build apps on Lovable, and run them in your Obsidian vault, all via a read-only REST API on the hosted Worker.

## Why not the main title / platform badge
The `works with Claude | ChatGPT | …` title and badge describe assistants that *natively run* a `SKILL.md`. n8n/Lovable/Obsidian consume skills through the REST API/exports (Obsidian needs an AI plugin, n8n its AI node, Lovable is an app builder), so they get their own "integrates with" billing rather than overstating native support — consistent with the precise wording already in the intro paragraph.

Links verified (connector guides + the `mcp-remote` REST API anchor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNrXCKwcDVSeh77n9o4aAR)_