### PR TITLE
docs + ci(launch): wave-2 posts + a Generate Launch Posts action

### DIFF
--- a/docs/launch-posts.md
+++ b/docs/launch-posts.md
@@ -183,3 +183,193 @@ Monday and composes ready-to-post X + LinkedIn copy (in the Action's job summary
 - [ ] Ask the first 20 users directly for a star + feedback
 - [ ] Repost the compare GIF monthly featuring a different skill
 - [ ] One deep-dive blog post per flagship skill (SEO long tail)
+
+---
+---
+
+# Launch wave 2 — the Brain + Integrations (v28.1.0)
+
+> **What's new since the v21 kit above:** **206 skills / 21 professions**, **196 eval-scored (avg 4.8/5)**, a read-only **REST API**, **n8n / Lovable / Obsidian** integrations, and the **Professional Brain** — a local markdown memory the skills read and write, plus an action layer that opens the tickets. Two fresh launch stories below; pick the angle per channel. *(The v21 posts above are stale at "174 skills" — refresh those numbers before reusing them, or use the wave-2 copy here.)*
+
+## New assets & links (all live)
+- **REST API:** https://pm-skills-mcp.pm-claude-skills.workers.dev/v1/skills
+- **Connectors (n8n · Lovable · Obsidian):** https://github.com/mohitagw15856/pm-claude-skills/tree/main/connectors
+- **Professional Brain (architecture):** https://github.com/mohitagw15856/pm-claude-skills/blob/main/BRAIN.md
+- **In-browser Brain:** https://mohitagw15856.github.io/pm-claude-skills/brain.html
+- **Quickstart:** https://github.com/mohitagw15856/pm-claude-skills/blob/main/BRAIN_QUICKSTART.md
+- **Install anywhere:** `npx pm-claude-skills add --agent claude` · `pip install pm-skills` · hosted MCP URL above
+
+---
+
+## Story A — "Skills that remember and act" (the Professional Brain)
+*Best angle for Hacker News and LinkedIn — it's a systems/architecture story, not a feature dump.*
+
+### A1. Hacker News — Show HN
+
+**Title** (factual, contrarian, no hype):
+> Show HN: A local, grep-able markdown memory for AI agents — no vector DB
+
+**Body:**
+> I maintain an open-source library of "skills" (structured `SKILL.md` files that teach Claude/
+> ChatGPT to produce real professional work — PRDs, postmortems, launch plans). The recurring
+> complaint was that every run starts cold: you re-paste context, and the *why* behind last
+> month's decisions evaporates.
+>
+> So I added a memory layer, and deliberately did the un-trendy thing: **no vector database, no
+> embeddings.** It's a plain `brain/` folder of markdown — `knowledge/`, `decisions/`,
+> `hypotheses/`, `stakeholders/`, `entities/`, `source/`. Skills read the relevant files before
+> they answer and append outcomes back after. Recall is a deterministic grep that ranks hits by a
+> **provenance tag** on every fact (`[data]` / `[interview]` / `[verbal]` / `[hunch]`), so a hunch
+> never gets laundered into a measured result. It's all human-readable and Obsidian-compatible —
+> you can open the graph and correct it by hand.
+>
+> The write-back and the *action* layer are the parts I was most nervous about, so they're
+> dry-run by default, append-only (decisions never overwrite — they accrete), and approval-gated
+> per risky action before anything opens a ticket or posts a message.
+>
+> Why markdown over a vector store: I wanted memory I can diff, audit, and grep — not a black box
+> I have to trust. For a single product's context it's been more useful than retrieval, and a lot
+> easier to debug.
+>
+> Quickstart (a folder + one file): https://github.com/mohitagw15856/pm-claude-skills/blob/main/BRAIN_QUICKSTART.md
+> MIT. Curious where people think deterministic markdown memory breaks down vs. embeddings.
+
+*First action after posting: reply to the first few comments fast; the embeddings-vs-markdown debate is the thread.*
+
+### A2. X / Twitter thread
+
+**1/**
+> AI tools forget everything between sessions. So you re-paste the same context forever, and last
+> quarter's decisions lose the "why."
+>
+> I gave my open-source AI skills a memory. No vector DB — just markdown you can grep. 🧵
+
+**2/**
+> It's a `brain/` folder: knowledge, decisions, hypotheses, stakeholders.
+> Skills read it before they answer and write outcomes back after.
+>
+> Every fact carries a provenance tag — `[data]`, `[interview]`, `[verbal]`, `[hunch]` — so a
+> gut call never gets treated like a measured one.
+
+**3/**
+> The scary part — letting it *act* (open tickets, post updates) — is dry-run by default,
+> append-only, and approval-gated per risky action.
+>
+> Nothing happens silently. Decisions accrete; they never overwrite.
+
+**4/**
+> Why markdown instead of embeddings? I wanted memory I can diff, audit, and fix by hand. Open
+> the folder as an Obsidian vault and it's a graph of what you know.
+
+**5/**
+> It's the memory layer for 206 open-source skills (PRDs, roadmaps, postmortems…), MIT.
+>
+> Try the in-browser version, no install: https://mohitagw15856.github.io/pm-claude-skills/brain.html
+> ⭐ https://github.com/mohitagw15856/pm-claude-skills
+
+### A3. LinkedIn
+
+> Every AI tool has the same blind spot: it forgets. You re-explain your product every session,
+> and the reasoning behind past decisions just disappears.
+>
+> So I built a memory layer for my open-source AI skills — and skipped the vector database on
+> purpose. It's plain markdown: a `brain/` folder of knowledge, decisions, hypotheses, and
+> stakeholders that the skills read before they answer and write back to after. Every fact is
+> tagged with where it came from, so a hunch is never mistaken for data. And when a skill acts on
+> its own advice — opening tickets, posting an update — it previews first and waits for your
+> approval. Nothing happens silently.
+>
+> The point: memory you can read, diff, and correct by hand — not a black box you have to trust.
+>
+> Free, MIT, and there's an in-browser version to try in a minute. Link in comments 👇
+
+*(Link in the first comment — LinkedIn suppresses posts with outbound links in the body.)*
+
+---
+
+## Story B — "Your AI skills, now everywhere" (Integrations + REST API)
+*Best angle for X, Reddit, and Product Hunt — it's a "use it in the tools you already live in" story.*
+
+### B1. X / Twitter thread
+
+**1/**
+> 206 open-source AI skills (PRDs, launch plans, postmortems…) just stopped being Claude-only.
+>
+> One read-only REST API → now they run inside n8n, power Lovable apps, and live in your Obsidian
+> vault. 🧵
+
+**2/**
+> **n8n:** drop the hosted MCP connector into an AI Agent node, or `GET /v1/skills/{name}` from an
+> HTTP Request node. Now any automation can turn a trigger into a structured PRD / exec update / GTM plan.
+
+**3/**
+> **Obsidian:** every skill exports as a vault note — run it as a Copilot/Text-Generator prompt on
+> the note you're in. Your skills and your knowledge base, same place.
+
+**4/**
+> **Lovable:** a paste-in knowledge snippet teaches its generator to wire the skills into any app
+> it builds — "add a PRD generator" just works, backed by the API.
+
+**5/**
+> It's one read-only, no-auth, CORS-open API:
+> `GET https://pm-skills-mcp.pm-claude-skills.workers.dev/v1/skills`
+>
+> Same catalogue as the MCP connector — for any HTTP/no-code tool (Make, Zapier, Retool…).
+
+**6/**
+> 206 skills, 21 professions, 196 eval-scored (avg 4.8/5). MIT.
+> Browser, your own key, no install: https://mohitagw15856.github.io/pm-claude-skills/
+> ⭐ https://github.com/mohitagw15856/pm-claude-skills
+
+### B2. Reddit (r/ClaudeAI, then r/n8n, r/ObsidianMD, r/ProductManagement)
+
+**Title:** I made my 206 open-source AI skills runnable in n8n, Obsidian, and Lovable via one REST API
+
+**Body:**
+> A while back I open-sourced a library of structured `SKILL.md` files that teach Claude/ChatGPT to
+> produce real professional work (PRDs, roadmaps, postmortems — 206 now, 21 professions, MIT).
+> The ask I kept getting was "great, but I don't live in Claude Code."
+>
+> So everything is now reachable through a read-only, no-auth REST API (the same catalogue the MCP
+> connector serves):
+> - **n8n** — MCP Client node, or an HTTP Request node hitting `/v1/skills/{name}`, feeds the skill
+>   into your own AI node. Trigger → structured artifact → wherever (Slack/Notion/a ticket).
+> - **Obsidian** — every skill exports as a vault note you can run as a Copilot / Text Generator prompt.
+> - **Lovable** — a knowledge snippet so its app generator can wire the skills in.
+>
+> API: https://pm-skills-mcp.pm-claude-skills.workers.dev/v1/skills · Repo: https://github.com/mohitagw15856/pm-claude-skills
+>
+> What tool should it plug into next?
+
+*Tailor the first line per subreddit (r/n8n: lead with the node; r/ObsidianMD: lead with the vault). Read each sub's self-promo rules; don't blast all at once.*
+
+### B3. LinkedIn
+
+> Your AI skills shouldn't be locked to one app.
+>
+> I open-sourced 206 professional AI skills — PRDs, launch plans, postmortems, the structure a
+> senior pro actually uses. They started as Claude-only. Now a single read-only REST API puts them
+> wherever you already work:
+>
+> → Automate them in **n8n** (a trigger becomes a finished doc)
+> → Run them in your **Obsidian** vault, on the note you're editing
+> → Build apps on them with **Lovable**
+>
+> Same skills, no install, your own model key. 206 skills, 21 professions, MIT.
+>
+> Link in comments 👇 Where would you want to run them?
+
+### B4. Product Hunt
+
+**Name:** PM Skills — 206 AI skills, now in n8n, Obsidian & Lovable
+**Tagline:** One REST API puts pro-grade AI skills in the tools you already use
+**Description:**
+> 206 open-source skills that teach AI to produce real professional work — now reachable through a
+> read-only REST API, so they run inside n8n automations, your Obsidian vault, and Lovable apps,
+> not just Claude. Eval-scored, chainable, MIT.
+
+**First comment (maker):**
+> Hey PH 👋 The #1 thing people told me about my AI-skills library was "I don't live in Claude
+> Code." So I added a no-auth REST API and wired up n8n, Obsidian, and Lovable — same 206 skills,
+> wherever you work. There's also a new memory layer (a local markdown "brain" the skills read and
+> write). Free, your own key. What tool should it plug into next?


### PR DESCRIPTION
Two related launch-content changes (same branch, so one PR):

## 1. Wave-2 launch posts — `docs/launch-posts.md`
The kit was stale (v21.1.0 / "174 skills"). Appends a **Launch wave 2 (v28.1.0)** section with ready-to-post copy for the two new stories — **the Professional Brain** (Show HN / X / LinkedIn) and **Integrations + REST API** (X / Reddit / LinkedIn / Product Hunt) — using current numbers (206 skills, 21 professions, 196 eval-scored) and verified-live links.

## 2. 🆕 "Generate Launch Posts" action — automate it next time
A manual workflow that does this generation for you on future launches:
- **`scripts/generate-launch-posts.mjs`** — reads the last ~10 **merged** PRs (filters out bot/chore noise), asks Claude to pick the new/groundbreaking features, and writes a ready-to-post draft (Show HN, X thread, LinkedIn, Reddit, Product Hunt) **plus a paste-ready Medium-article prompt** to `docs/launch-drafts/launch-posts-<date>.md`. `--dry-run` prints the prompt with no API call.
- **`.github/workflows/generate-launch-posts.yml`** — `workflow_dispatch` (inputs: `pr_count`, `model`), runs the script with `ANTHROPIC_API_KEY`, and opens a PR with the draft (via `peter-evans/create-pull-request`, since `main` is protected).
- **`docs/launch-drafts/`** — output folder for generated drafts.

**Tested:** script syntax-checks; `--dry-run` against stubbed PR data correctly keeps feature/docs PRs and filters the `skill-of-the-week` / `chore(evals)` / unmerged noise; workflow YAML validates.

**How you'll run it:** Actions → **Generate Launch Posts** → Run workflow → it opens a PR with the draft. (I can't dispatch it — read-only token — so that click is yours after merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)