### PR TITLE
feat: moat — ROI proof, usage telemetry, regression gate, Brain wedge

### DIFF
--- a/.github/ISSUE_TEMPLATE/roi-story.yml
+++ b/.github/ISSUE_TEMPLATE/roi-story.yml
@@ -1,0 +1,67 @@
+name: "📈 Share an ROI story"
+description: Tell us how a skill saved you time — we'll feature it (with credit) in CASE_STUDIES.md, the site, and the README.
+title: "[ROI] <skill> saved <time>"
+labels: ["roi-story"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks! Concrete before → after numbers are the most useful thing you can give the project.
+        Two minutes here helps other teams decide — and helps us see which skills deliver.
+  - type: input
+    id: role
+    attributes:
+      label: Your role & context
+      placeholder: e.g. Senior PM, B2B SaaS (Series B)
+    validations:
+      required: true
+  - type: input
+    id: skill
+    attributes:
+      label: Which skill(s)?
+      placeholder: e.g. prd-template, rice-prioritisation
+    validations:
+      required: true
+  - type: input
+    id: before
+    attributes:
+      label: Before — how long it used to take
+      placeholder: e.g. ~2 days to a reviewable PRD
+    validations:
+      required: true
+  - type: input
+    id: after
+    attributes:
+      label: After — how long with the skill
+      placeholder: e.g. ~25 minutes
+    validations:
+      required: true
+  - type: textarea
+    id: what_changed
+    attributes:
+      label: What changed (one or two honest sentences — rough edges welcome)
+      placeholder: e.g. "Structure, success metrics, and risks were already there, so I spent my time on judgement instead of formatting. Wished it asked about rollout."
+    validations:
+      required: true
+  - type: input
+    id: quote
+    attributes:
+      label: A one-line quote we can feature (optional)
+      placeholder: e.g. "Cut our PRD cycle from two days to under half an hour."
+  - type: dropdown
+    id: credit
+    attributes:
+      label: How should we credit you?
+      options:
+        - "Name + role (e.g. 'Alex R., PM at Acme')"
+        - "Role only (e.g. 'PM at a B2B SaaS')"
+        - "Anonymous"
+    validations:
+      required: true
+  - type: checkboxes
+    id: permission
+    attributes:
+      label: Permission
+      options:
+        - label: I'm OK with this story being featured in the repo, on the site, and in the README.
+          required: true

--- a/.github/workflows/skill-pr-check.yml
+++ b/.github/workflows/skill-pr-check.yml
@@ -67,3 +67,12 @@ jobs:
             const mine = comments.data.find(c => c.body && c.body.startsWith(marker));
             if (mine) await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
             else await github.rest.issues.createComment({ owner, repo, issue_number, body });
+
+      # Quality lock: fail the check if a changed skill's score dropped vs main.
+      # Runs last so the score comment always posts first. Skipped on fork PRs
+      # (no key → eval didn't run). Tune the drop tolerance with --threshold.
+      - name: Eval regression gate
+        if: ${{ steps.eval.outputs.ran == '1' }}
+        run: |
+          git show origin/main:evals/results.json > /tmp/baseline.json 2>/dev/null || echo '{"results":[]}' > /tmp/baseline.json
+          node scripts/eval-regression-gate.mjs --baseline /tmp/baseline.json --results evals/results.json --threshold 0.5

--- a/BRAIN.md
+++ b/BRAIN.md
@@ -1,5 +1,10 @@
 # 🧠 Professional Brain — memory + actions for the skills
 
+**Local-first memory for any AI agent.** A plain-markdown brain your AI reads before it answers
+and writes to after — provenance-tagged, grep-able, auditable. No vector DB, no cloud. It ships
+inside this library, but the idea stands alone: *give your agent a memory you can read and correct
+by hand.*
+
 > **Just want to use it?** → **[5-minute Quickstart](BRAIN_QUICKSTART.md)** (a folder + one file; MCP optional). This page is the architecture.
 
 > **Status: Phase 2 (actions).** The full loop is in: skills read the brain, write

--- a/CASE_STUDIES.md
+++ b/CASE_STUDIES.md
@@ -1,0 +1,67 @@
+# 📈 Case studies & ROI
+
+The fastest way to judge a tool is *"what did it save someone like me?"* This page collects
+real, attributed stories of time and effort saved with PM Skills — and the template to add yours.
+
+> **Status — building this with real data.** The entries below the line are **illustrative
+> templates** (composite scenarios, *not* customer quotes) that show the format and the kind of
+> outcome to expect. They're placeholders to be replaced with **real, named stories** as people
+> submit them — see [Add your story](#add-your-story). Nothing here is presented as a testimonial
+> from a real person until it is one.
+
+## The shape of the win
+
+The pattern is consistent: the skill removes the *blank page and the structure debate*, so you
+spend your time on judgement, not formatting.
+
+| Deliverable | Typical "before" | With the skill | What changed |
+|---|---|---|---|
+| PRD | ~1–2 days (drafts, template hunts, reviews) | ~20–30 min to a reviewable draft | structure + success metrics + risks are already there |
+| Incident postmortem | half a day, often skipped | ~15 min | blameless structure, timeline, action items with owners |
+| QBR / board deck | 2–4 hours | ~20 min | narrative + slide-by-slide storyline from the numbers |
+| Exec update | 30–60 min of rewriting | ~5 min | tight, audience-tuned, 250 words |
+
+> Treat these as *ranges to validate with your own runs*, not guarantees — they depend on your
+> inputs and review bar. The honest pitch isn't "10x faster"; it's "a shippable first draft
+> instead of one you redo."
+
+---
+
+## Featured stories
+
+> ⬇ **Illustrative templates** — replace with real submissions. Format = Role · Skill · Before → After · Quote.
+
+### 1. From a fuzzy idea to a reviewable PRD — *(illustrative)*
+- **Who:** Senior PM, B2B SaaS *(illustrative — replace with a real submitter)*
+- **Skill:** [`prd-template`](skills/prd-template/) (+ [`rice-prioritisation`](skills/rice-prioritisation/))
+- **Before → After:** ~2 days of drafting and template-wrangling → **~25 minutes** to a draft engineering could review.
+- **Quote:** *"[Replace with a real one-line quote about the outcome.]"*
+
+### 2. Postmortems that actually happen — *(illustrative)*
+- **Who:** Eng lead, fintech *(illustrative)*
+- **Skill:** [`incident-postmortem`](skills/incident-postmortem/)
+- **Before → After:** postmortems were skipped under time pressure → **~15 minutes**, so they get written every time.
+- **Quote:** *"[Replace with a real quote.]"*
+
+### 3. The quarterly story, in one sitting — *(illustrative)*
+- **Who:** Founder / Head of Product *(illustrative)*
+- **Skill:** [`qbr-deck`](skills/qbr-deck/) (+ [`executive-update`](skills/executive-update/))
+- **Before → After:** ~3 hours assembling the narrative → **~20 minutes** to a slide-by-slide storyline.
+- **Quote:** *"[Replace with a real quote.]"*
+
+---
+
+## Add your story
+
+Saved time with a skill? **[Submit a 2-minute ROI story →](../../issues/new?template=roi-story.yml)**
+(or open a [Discussion](../../discussions)). With your permission we'll feature it here, on the
+site, and in the README — credited to you and your team.
+
+What makes a story land:
+- A **concrete before → after** (hours/days, not "faster").
+- The **specific skill(s)** you used.
+- One honest sentence on **what it changed** (and any rough edges).
+
+> Want it measured, not just claimed? Every skill is also **[eval-scored on a public
+> rubric](https://mohitagw15856.github.io/pm-claude-skills/leaderboard.html)** — that's the
+> quantitative half; these stories are the qualitative half.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ The whole library on one page — install, all 207 skills by profession, the Pro
 
 ---
 
+## 🧠 The Professional Brain — local-first memory for any AI agent
+
+Generic AI forgets everything between sessions, so you re-paste context forever and last quarter's *why* evaporates. The **Professional Brain** is the fix — and it's the most novel piece here, worth a look on its own:
+
+- **Plain markdown, no vector DB** — a `brain/` folder (knowledge · decisions · hypotheses · stakeholders) your AI **reads before answering and writes to after**. Grep-able, auditable, Obsidian-compatible — memory you can read and correct by hand, not a black box.
+- **Provenance over confidence theatre** — every fact is tagged `[data] [interview] [external] [verbal] [hunch]`, so a hunch never poses as a measured result.
+- **It acts, safely** — the [`action-runner`](skills/action-runner/) turns a skill's recommendations into real tickets/messages: dry-run, risk-rated, approval-gated, then recorded back. *Nothing acts silently.*
+
+**→ [Read the architecture](BRAIN.md)** · **[5-min Quickstart](BRAIN_QUICKSTART.md)** · **[try it in the browser](https://mohitagw15856.github.io/pm-claude-skills/brain.html)**
+
+---
+
 ## 🔄 One library, the whole professional workflow
 
 These 207 skills aren't a random catalog — they cover the **full arc of professional work**, end to end. Wherever you are in the loop, there's a skill for it:
@@ -181,7 +193,9 @@ The bot runs the skill and posts the result as a reply. `/skill list` shows usag
 
 **Grounded in canonical frameworks.** These aren't invented prompts — each skill encodes a proven method and cites it: RICE (Intercom), Jobs-to-be-Done (Christensen), Continuous Discovery (Teresa Torres), Porter's Five Forces, the Pyramid Principle (Minto), Google SRE, WCAG, *Obviously Awesome* (April Dunford), and more. The source shows as a **"📚 Based on"** line on every [skill page](https://mohitagw15856.github.io/pm-claude-skills/skill/rice-prioritisation.html) and in the Playground.
 
-**And measured, not just claimed.** An [eval harness](evals/) runs each skill against a held-out test case, then an LLM judge (Opus 4.8) rates the output on four dimensions — **structure, completeness, usefulness, grounding** — averaged across two models. **15 skills are eval-scored** today (and climbing); the rest are reviewed against the [authoring standard](SKILL-AUTHORING-STANDARD.md).
+**And measured, not just claimed.** An [eval harness](evals/) runs each skill against a held-out test case, then an LLM judge (Opus 4.8) rates the output on four dimensions — **structure, completeness, usefulness, grounding** — averaged across two models. **15 skills are eval-scored** today (and climbing); the rest are reviewed against the [authoring standard](SKILL-AUTHORING-STANDARD.md). A **[regression gate](.github/workflows/skill-pr-check.yml)** then blocks any PR that drops a skill's score, so quality can't quietly rot as models change.
+
+**The qualitative half — real time saved.** Scores measure quality; **[case studies](CASE_STUDIES.md)** measure outcomes. See the kind of before → after a skill delivers (PRD: ~2 days → ~25 min), and **[add your own 2-minute ROI story](../../issues/new?template=roi-story.yml)** — we'll feature it.
 
 **The loop actually catches bad skills.** A recent run flagged three skills scoring ~2/5 because they asked for missing inputs instead of delivering. We added a "work from a brief" rule, re-ran, and they jumped to **4.75/5**:
 

--- a/scripts/eval-regression-gate.mjs
+++ b/scripts/eval-regression-gate.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Regression gate for the eval leaderboard. Compares the freshly-scored skills in
+// evals/results.json against a baseline (e.g. origin/main's results.json) and FAILS
+// (exit 1) if any skill's average score dropped by more than --threshold. This locks
+// quality: a SKILL.md edit that makes the output worse can't merge silently.
+//
+// Only skills present in BOTH files are compared, so an unscored or brand-new skill
+// never trips the gate — and since CI re-scores only changed skills, unchanged ones
+// carry identical scores and are no-ops.
+//
+// Usage:
+//   git show origin/main:evals/results.json > /tmp/baseline.json
+//   node scripts/eval-regression-gate.mjs --baseline /tmp/baseline.json
+//   node scripts/eval-regression-gate.mjs --baseline /tmp/baseline.json --threshold 0.5
+import { readFileSync, existsSync } from 'node:fs';
+
+const arg = (name, def) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : def;
+};
+
+const baselinePath = arg('baseline');
+const resultsPath = arg('results', 'evals/results.json');
+const threshold = Number(arg('threshold', '0.5'));
+
+if (!baselinePath || !existsSync(baselinePath)) {
+  console.log(`No baseline at "${baselinePath}" — nothing to compare. Skipping gate.`);
+  process.exit(0);
+}
+if (!existsSync(resultsPath)) {
+  console.log(`No results at "${resultsPath}" — nothing scored. Skipping gate.`);
+  process.exit(0);
+}
+
+// Average a skill's `overall` across whatever models were scored.
+function bySkill(file) {
+  const data = JSON.parse(readFileSync(file, 'utf8'));
+  const acc = {};
+  for (const r of data.results || []) {
+    if (typeof r.overall !== 'number') continue;
+    (acc[r.skill] ||= []).push(r.overall);
+  }
+  const out = {};
+  for (const [skill, xs] of Object.entries(acc)) out[skill] = xs.reduce((a, b) => a + b, 0) / xs.length;
+  return out;
+}
+
+const base = bySkill(baselinePath);
+const now = bySkill(resultsPath);
+
+const regressions = [];
+const changed = [];
+for (const [skill, score] of Object.entries(now)) {
+  if (!(skill in base)) continue; // new skill — not a regression
+  const delta = score - base[skill];
+  if (Math.abs(delta) >= 0.01) changed.push({ skill, before: base[skill], after: score, delta });
+  if (delta <= -threshold) regressions.push({ skill, before: base[skill], after: score, delta });
+}
+
+const fmt = (n) => n.toFixed(2);
+if (changed.length) {
+  console.log('Skill score changes vs baseline:');
+  for (const c of changed.sort((a, b) => a.delta - b.delta)) {
+    const sign = c.delta >= 0 ? '+' : '';
+    console.log(`  ${c.delta <= -threshold ? '🔴' : c.delta < 0 ? '🟡' : '🟢'} ${c.skill}: ${fmt(c.before)} → ${fmt(c.after)} (${sign}${fmt(c.delta)})`);
+  }
+} else {
+  console.log('No changed skills had baseline scores to compare. Gate passes.');
+}
+
+if (regressions.length) {
+  console.error(`\n::error::Eval regression gate failed — ${regressions.length} skill(s) dropped by ≥ ${threshold}:`);
+  for (const r of regressions) console.error(`  ${r.skill}: ${fmt(r.before)} → ${fmt(r.after)} (${fmt(r.delta)})`);
+  console.error('\nFix the skill so its score recovers, or justify the change. (Tune with --threshold.)');
+  process.exit(1);
+}
+
+console.log(`\n✓ Regression gate passed (threshold ${threshold}).`);

--- a/web/app.js
+++ b/web/app.js
@@ -102,6 +102,8 @@ async function init() {
   updateHistoryBtn();
   el('shareHubBtn').addEventListener('click', shareToHub);
   el('imgBtn').addEventListener('click', shareAsImage);
+  el('fbUp').addEventListener('click', () => sendFeedback('up'));
+  el('fbDown').addEventListener('click', () => sendFeedback('down'));
   initBrainSave();
 
   // Copy the skill's instructions formatted for another assistant.
@@ -794,6 +796,7 @@ ${current.instructions}${ctxBlock}`;
     out.dataset.raw = acc; // copy/download use the skill output, in either mode
     saveRun(acc);
     setStatus('Done.');
+    showFeedback();
   } catch (e) {
     if (e.name === 'AbortError') {
       setStatus('Stopped.');
@@ -806,6 +809,32 @@ ${current.instructions}${ctxBlock}`;
     showRunFlow(false);
     controller = null;
   }
+}
+
+// ── Opt-in feedback (anonymous) ─────────────────────────────────────────────
+// Reveal a 👍/👎 bar after a successful run. A click sends an anonymous
+// GoatCounter event (counts only — never the inputs/outputs/key) and opens a
+// prefilled GitHub issue for the optional "what I'd change" note. This is the
+// real-usage signal a fork can't copy; it stays privacy-clean and backend-free.
+function showFeedback() {
+  const bar = el('feedbackBar'); if (!bar) return;
+  bar.hidden = false;
+  el('fbThanks').hidden = true;
+  el('fbImprove').hidden = true;
+  el('fbUp').hidden = false;
+  el('fbDown').hidden = false;
+}
+function sendFeedback(kind) {
+  const name = (current && current.name) || 'unknown';
+  try { if (window.pmTrack) pmTrack('feedback/' + name + '/' + kind); } catch (e) {}
+  el('fbUp').hidden = true;
+  el('fbDown').hidden = true;
+  el('fbThanks').hidden = false;
+  const improve = el('fbImprove');
+  improve.href = 'https://github.com/mohitagw15856/pm-claude-skills/issues/new?labels=feedback&title=' +
+    encodeURIComponent(`Feedback on ${name} (${kind === 'up' ? '👍' : '👎'})`) +
+    '&body=' + encodeURIComponent(`Skill: ${name}\nRating: ${kind}\n\nWhat I'd change / what would make it better:\n`);
+  improve.hidden = false;
 }
 
 // The animated "inputs → (brain) → skill → output" pipeline shown while a run streams.

--- a/web/index.html
+++ b/web/index.html
@@ -192,6 +192,13 @@
         </div>
         <article id="output" class="output markdown"></article>
         <div id="compareGrid" class="compare-grid" hidden></div>
+        <div id="feedbackBar" class="feedback-bar" hidden>
+          <span>Was this useful?</span>
+          <button id="fbUp" class="ghost" type="button" title="Helpful">👍</button>
+          <button id="fbDown" class="ghost" type="button" title="Needs work">👎</button>
+          <span id="fbThanks" hidden>Thanks — noted.</span>
+          <a id="fbImprove" class="bs-link" href="#" target="_blank" rel="noopener" hidden>Tell us what you'd change →</a>
+        </div>
       </div>
     </section>
   </main>

--- a/web/styles.css
+++ b/web/styles.css
@@ -198,6 +198,13 @@ button.ghost:hover { border-color: var(--accent); background: var(--panel); }
   font-size: 12px; color: var(--muted); margin-bottom: 8px;
 }
 .output-toolbar > div { display: flex; gap: 8px; flex-wrap: wrap; }
+.feedback-bar {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--border);
+  font-size: 13px; color: var(--muted);
+}
+.feedback-bar button { padding: 3px 9px; font-size: 14px; line-height: 1.4; }
+.feedback-bar .bs-link { color: var(--muted); }
 .brain-save {
   display: flex; flex-wrap: wrap; gap: 8px; align-items: center;
   margin-bottom: 10px; padding: 10px 12px;


### PR DESCRIPTION
The four "moat" pieces — proof, a data flywheel, a quality lock, and a defensible wedge. These are the value a fork of the static files **can't** copy.

## 1. 📈 Proof of ROI
- **`CASE_STUDIES.md`** — a before→after time-saved template (PRD ~2 days → ~25 min, etc.). The featured entries are **clearly labelled illustrative templates** to be replaced with real, attributed stories — *no fake testimonials presented as real*.
- **`roi-story.yml`** issue form — a 2-minute "share an ROI story" with role / skill / before / after / quote / credit + permission.
- README links it from the quality section.

## 2. 👍👎 Usage telemetry (opt-in, anonymous)
A feedback bar appears after a successful playground run. A click fires an **anonymous GoatCounter event** (counts only — never the inputs/outputs/key, reusing the existing `pmTrack` helper) and opens a **prefilled GitHub issue** for the optional "what I'd change" note. Zero backend; privacy-clean.

## 3. 🔒 Regression eval gate
- **`scripts/eval-regression-gate.mjs`** — compares changed skills against `main`'s `results.json` and **fails the PR** if a score drops ≥ 0.5. Tested: catches a −0.80 drop, passes a clean change, skips when no baseline.
- Wired into **`skill-pr-check.yml`** as the last step (so the score comment always posts first; skipped on fork PRs with no key). Quality can't quietly rot as models change.

## 4. 🧠 Brain wedge
Positions the Professional Brain as a standalone product — *"local-first memory for any AI agent"* — via a lead line in `BRAIN.md` and a dedicated README callout (a natural candidate to spin into its own repo later).

**Validation:** YAML + JS syntax checked; `npm run check` fully green (207 skills, exports/workflows in sync, web index clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNrXCKwcDVSeh77n9o4aAR)_