### PR TITLE
feat(community): promote Community Skills across README, nav & hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,24 @@ Full details and where the money goes: **[SPONSORS.md](SPONSORS.md)**.
 
 ---
 
+## 🌐 Community Skills — get listed, earn the badge
+
+Built your own skills? **[List them in the Community Skills directory](COMMUNITY-SKILLS.md)** —
+a place to showcase skill repos and packs that follow the `SKILL.md` standard. It's a **one-row
+pull request**, and once it's merged you earn a badge to show off in your own repo:
+
+[![Featured in PM Skills Community](https://img.shields.io/badge/Featured%20in-PM%20Skills%20Community-d97757?logo=anthropic&logoColor=white)](COMMUNITY-SKILLS.md)
+
+```markdown
+[![Featured in PM Skills Community](https://img.shields.io/badge/Featured%20in-PM%20Skills%20Community-d97757?logo=anthropic&logoColor=white)](https://github.com/mohitagw15856/pm-claude-skills/blob/main/COMMUNITY-SKILLS.md)
+```
+
+Community listings live in their authors' own repos and are **community-maintained — not
+eval-scored or security-audited** (that's the [curated library](#️-all-313-skills) above). Want
+your skill *in* the curated library instead? See **Contributing** below.
+
+---
+
 ## 🤝 Contributing — Add Your Skill
 
 <details>

--- a/scripts/build-community.mjs
+++ b/scripts/build-community.mjs
@@ -41,6 +41,9 @@ const sotw = existsSync(join(root, 'web', 'skill-of-the-week.json'))
 
 const stars = repo?.stargazers_count ?? '—';
 const forks = repo?.forks_count ?? '—';
+// Skill count from the built catalogue (avoids a hardcoded number going stale).
+const skillCount = existsSync(join(root, 'web', 'skills.json'))
+  ? (JSON.parse(readFileSync(join(root, 'web', 'skills.json'), 'utf8')).count ?? '—') : '—';
 
 const contribHtml = (contributors || []).filter((c) => c.type === 'User').slice(0, 24).map((c) =>
   `<a class="contrib" href="${c.html_url}" title="${esc(c.login)} · ${c.contributions} contributions"><img src="${c.avatar_url}&s=80" alt="${esc(c.login)}" loading="lazy" /></a>`
@@ -103,7 +106,7 @@ const html = `<!DOCTYPE html>
   <div class="stats">
     <div class="stat"><b>⭐ ${stars}</b><br><span>stars</span></div>
     <div class="stat"><b>🍴 ${forks}</b><br><span>forks</span></div>
-    <div class="stat"><b>180</b><br><span>skills</span></div>
+    <div class="stat"><b>${skillCount}</b><br><span>skills</span></div>
   </div>
 
   <div class="hub-cta">
@@ -111,6 +114,7 @@ const html = `<!DOCTYPE html>
     <a class="btn btn-ghost" href="${'https://github.com/' + REPO}/discussions/new?category=show-and-tell">📣 Show & Tell what you built</a>
     <a class="btn btn-ghost" href="${'https://github.com/' + REPO}/discussions/new?category=recipes">🧩 Share a recipe</a>
     <a class="btn btn-ghost" href="${'https://github.com/' + REPO}/issues/new?template=submit-skill.yml">🧠 Submit a skill</a>
+    <a class="btn btn-ghost" href="${'https://github.com/' + REPO}/blob/main/COMMUNITY-SKILLS.md">🌐 Get listed + earn the badge</a>
   </div>
 
   ${sotw ? `<div class="card sotw" style="margin-bottom:18px">🛠️ <strong>Skill of the week:</strong> <a href="${BASE}/skill/${sotw.skill}.html">${esc(sotw.title)}</a> — ${esc(sotw.summary || '')}</div>` : ''}

--- a/web/nav.js
+++ b/web/nav.js
@@ -72,6 +72,8 @@
       ['learn.html', '🎓 Learn'],
       ['guide.html', '📖 Guide'],
       ['community.html', '💬 Community'],
+      // External (GitHub doc): a 3rd truthy element renders it as a new-tab link.
+      ['https://github.com/mohitagw15856/pm-claude-skills/blob/main/COMMUNITY-SKILLS.md', '🌐 Community Skills', true],
     ] },
     { href: 'pro.html', label: '⭐ Pro' },
     // Always-visible way back to the source — opens the GitHub repo in a new tab.
@@ -88,7 +90,7 @@
     var here = it.items.some(function (t) { return t[0] === file; });
     return '<span class="tool-group">'
       + '<button type="button" class="tool group-btn' + (here ? ' active' : '') + '" aria-haspopup="true" aria-expanded="false">' + it.group + ' ▾</button>'
-      + '<span class="group-menu" hidden>' + it.items.map(function (t) { return link(t[0], t[1]); }).join('') + '</span>'
+      + '<span class="group-menu" hidden>' + it.items.map(function (t) { return t[2] ? '<a class="tool" href="' + t[0] + '" target="_blank" rel="noopener">' + t[1] + '</a>' : link(t[0], t[1]); }).join('') + '</span>'
       + '</span>';
   }).join('');
 


### PR DESCRIPTION
## What does this PR add or change?

Surfaces the new **Community Skills** program (merged in #97) so people actually discover it and contribute — the listing flow only works if it's visible.

---

## Type of change

- [x] Documentation / community feature promotion

---

## Where it now shows up

1. **README — a visible section** ("🌐 Community Skills — get listed, earn the badge") with the badge **rendered live** and a copy-paste snippet, right before Contributing. (It was previously a single line inside a collapsed `<details>`.)
2. **Playground nav** (`web/nav.js`) — a **🌐 Community Skills** entry in the Explore dropdown that opens the directory in a new tab. Group items now support an external link via an optional 3rd element, so it behaves like the GitHub button.
3. **Community hub** (`community.html` via `build-community.mjs`) — a **"Get listed + earn the badge"** CTA alongside the other community actions. While there, the hub's **skills stat is now read from `skills.json`** (was hardcoded `180` → live **313**), so it won't go stale again.
4. **The badge as the canonical example** — rendered in the new README section with its snippet, so contributors can see and copy exactly what they'll earn.

---

## Notes

- Curated library is untouched — verified no changes under `skills/` or `exports/`.
- `community.html` is generated at deploy (gitignored); only its generator changed. Scripts syntax-checked; the README anchor matches the existing canonical form.
- Single focused commit off latest `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_