### PR TITLE
fix(community): Product Notes-branded badge (drop the Anthropic logo)

### DIFF
--- a/COMMUNITY-SKILLS.md
+++ b/COMMUNITY-SKILLS.md
@@ -4,7 +4,7 @@ A directory of **skill repos and packs built by the community** that follow the
 [`SKILL.md` standard](SKILL-AUTHORING-STANDARD.md). Get your skills listed, and earn a
 **badge** for your own repo that shows they're part of the PM Skills community. 🏅
 
-[![Featured in PM Skills Community](https://img.shields.io/badge/Featured%20in-PM%20Skills%20Community-d97757?logo=anthropic&logoColor=white)](https://github.com/mohitagw15856/pm-claude-skills/blob/main/COMMUNITY-SKILLS.md)
+[![Featured in PM Skills Community](https://mohitagw15856.github.io/pm-claude-skills/assets/community-badge.svg)](https://github.com/mohitagw15856/pm-claude-skills/blob/main/COMMUNITY-SKILLS.md)
 
 > [!IMPORTANT]
 > **This is not the curated library.** The skills *in this repo* (`skills/`) are
@@ -65,12 +65,12 @@ back to this directory:
 
 **Markdown**
 ```markdown
-[![Featured in PM Skills Community](https://img.shields.io/badge/Featured%20in-PM%20Skills%20Community-d97757?logo=anthropic&logoColor=white)](https://github.com/mohitagw15856/pm-claude-skills/blob/main/COMMUNITY-SKILLS.md)
+[![Featured in PM Skills Community](https://mohitagw15856.github.io/pm-claude-skills/assets/community-badge.svg)](https://github.com/mohitagw15856/pm-claude-skills/blob/main/COMMUNITY-SKILLS.md)
 ```
 
 **HTML**
 ```html
-<a href="https://github.com/mohitagw15856/pm-claude-skills/blob/main/COMMUNITY-SKILLS.md"><img src="https://img.shields.io/badge/Featured%20in-PM%20Skills%20Community-d97757?logo=anthropic&logoColor=white" alt="Featured in PM Skills Community" /></a>
+<a href="https://github.com/mohitagw15856/pm-claude-skills/blob/main/COMMUNITY-SKILLS.md"><img src="https://mohitagw15856.github.io/pm-claude-skills/assets/community-badge.svg" alt="Featured in PM Skills Community" /></a>
 ```
 
 It renders like the badge at the top of this page. Wear it with pride. 🏅

--- a/README.md
+++ b/README.md
@@ -901,10 +901,10 @@ Built your own skills? **[List them in the Community Skills directory](COMMUNITY
 a place to showcase skill repos and packs that follow the `SKILL.md` standard. It's a **one-row
 pull request**, and once it's merged you earn a badge to show off in your own repo:
 
-[![Featured in PM Skills Community](https://img.shields.io/badge/Featured%20in-PM%20Skills%20Community-d97757?logo=anthropic&logoColor=white)](COMMUNITY-SKILLS.md)
+[![Featured in PM Skills Community](https://mohitagw15856.github.io/pm-claude-skills/assets/community-badge.svg)](COMMUNITY-SKILLS.md)
 
 ```markdown
-[![Featured in PM Skills Community](https://img.shields.io/badge/Featured%20in-PM%20Skills%20Community-d97757?logo=anthropic&logoColor=white)](https://github.com/mohitagw15856/pm-claude-skills/blob/main/COMMUNITY-SKILLS.md)
+[![Featured in PM Skills Community](https://mohitagw15856.github.io/pm-claude-skills/assets/community-badge.svg)](https://github.com/mohitagw15856/pm-claude-skills/blob/main/COMMUNITY-SKILLS.md)
 ```
 
 Community listings live in their authors' own repos and are **community-maintained — not

--- a/web/assets/community-badge.svg
+++ b/web/assets/community-badge.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="232" height="20" role="img" aria-label="Featured in PM Skills Community">
+  <title>Featured in PM Skills Community</title>
+  <defs>
+    <linearGradient id="pn" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#e0855f"/>
+      <stop offset="1" stop-color="#d9605a"/>
+    </linearGradient>
+    <clipPath id="round"><rect width="232" height="20" rx="3"/></clipPath>
+  </defs>
+  <g clip-path="url(#round)">
+    <rect width="100" height="20" fill="#0d0f14"/>
+    <rect x="100" width="132" height="20" fill="url(#pn)"/>
+  </g>
+  <!-- Product Notes "PM" mark -->
+  <rect x="4" y="3" width="14" height="14" rx="3" fill="url(#pn)"/>
+  <text x="11" y="13.5" font-family="Verdana,DejaVu Sans,Geneva,sans-serif" font-size="7.5" font-weight="700" text-anchor="middle" fill="#1a1207">PM</text>
+  <g font-family="Verdana,DejaVu Sans,Geneva,sans-serif" font-size="11">
+    <text x="60" y="15" text-anchor="middle" fill="#010101" fill-opacity=".3">Featured in</text>
+    <text x="60" y="14" text-anchor="middle" fill="#ffffff">Featured in</text>
+    <text x="166" y="15" text-anchor="middle" fill="#010101" fill-opacity=".3" font-weight="600">PM Skills Community</text>
+    <text x="166" y="14" text-anchor="middle" fill="#1a1207" font-weight="600">PM Skills Community</text>
+  </g>
+</svg>


### PR DESCRIPTION
## What does this PR add or change?

Fixes the **Community Skills** badge branding. It was rendered via shields.io with `logo=anthropic`, which pulled the **Anthropic** logo — wrong for a Product Notes / PM Skills program.

---

## Type of change

- [x] Fix (incorrect branding)

---

## The fix

- **New self-contained badge** at [`web/assets/community-badge.svg`](web/assets/community-badge.svg) — uses the actual Product Notes brand: the **"PM" gradient mark** (`#e0855f → #d9605a`) on `#0d0f14`, reading `[PM] Featured in │ PM Skills Community`. No external logo dependency.
- Swapped it in across **all references** — the README "Community Skills" section (rendered badge + snippet) and `COMMUNITY-SKILLS.md` (top badge + Markdown + HTML snippets).
- The separate **"official Anthropic plugin directory"** badge is left untouched — that one genuinely refers to Anthropic, so its logo is correct.

## Notes

- The badge image is served from GitHub Pages, so it renders live after this merges + Pages redeploys. You can preview the SVG itself right now by opening `web/assets/community-badge.svg` (GitHub renders SVG blobs).
- Branched fresh off the latest `main` (which already has the promotion section but the old badge); single focused commit, 3 files. Curated library untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_