### PR TITLE
chore(release): bump version to 35.0.0 to match the v35.0.0 tag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "pm-claude-skills",
-  "version": "34.0.0",
+  "version": "35.0.0",
   "description": "PM stands for Professional, not just Product Management. 391 Claude Skills + 4 agent templates across 56 bundles covering 25 professions — engineering, AI/ML, customer success, legal, finance, personal finance, HR, sales, design, Figma, marketing, social media, writers, developer relations, founders/startups, healthcare, nonprofit, crisis comms, educators, content creators, and more. Built by a PM, used by everyone. Building blocks for the Anthropic agent template architecture.",
   "owner": {
     "name": "Mohit Aggarwal",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "pm-claude-skills",
-  "version": "34.0.0",
+  "version": "35.0.0",
   "type": "module",
   "mcpName": "io.github.mohitagw15856/pm-claude-skills",
-  "description": "354 professional Agent Skills (SKILL.md) + subagents + slash commands for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes. It's a CLI, not a library: run `npx pm-claude-skills add --agent <tool>` to install into your AI tool — no `npm install` needed. Or try any skill free at https://mohitagw15856.github.io/pm-claude-skills/",
+  "description": "400 professional Agent Skills (SKILL.md) + subagents + slash commands for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes. It's a CLI, not a library: run `npx pm-claude-skills add --agent <tool>` to install into your AI tool — no `npm install` needed. Or try any skill free at https://mohitagw15856.github.io/pm-claude-skills/",
   "keywords": [
     "claude",
     "claude-code",

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.mohitagw15856/pm-claude-skills",
-  "description": "354 professional Agent Skills + workflow recipes — searchable & fetchable over MCP.",
+  "description": "400 professional Agent Skills + workflow recipes — searchable & fetchable over MCP.",
   "repository": {
     "url": "https://github.com/mohitagw15856/pm-claude-skills",
     "source": "github"
   },
-  "version": "34.0.0",
+  "version": "35.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "pm-claude-skills",
-      "version": "34.0.0",
+      "version": "35.0.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Fixes the failing release workflow: the `v35.0.0` tag didn't match `package.json` (still `34.0.0`).

Bumps all version fields to **35.0.0** and refreshes the stale skill count in the npm / MCP descriptions:
- `package.json` — version `34.0.0 → 35.0.0`; description `354 → 400 skills`
- `.claude-plugin/marketplace.json` — version `34.0.0 → 35.0.0`
- `server.json` — top-level + package version `34.0.0 → 35.0.0`; description `354 → 400 skills`

### ⚠️ After merging — re-point the tag
The `35.0.0` tag currently points at the pre-bump commit, so it still won't match until the tag moves to include this commit. Once this is merged to `main`:

```bash
git fetch origin main
git tag -f 35.0.0 origin/main   # move the tag to the bumped commit
git push origin 35.0.0 --force  # update the tag
```

Then re-run the failed **Publish** workflow (or delete + recreate the GitHub Release on the new tag). The version check will pass (`tag 35.0.0 == package.json 35.0.0`).

> Left untouched: `CHANGELOG.md` (its `[Unreleased]` section has older content you curate) and the README "Latest" blurb — happy to update those in a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_