### PR TITLE
feat(playground): daily challenge, embed snippet & skill remix

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -163,6 +163,10 @@ async function init() {
   // "Which skill do I need?" recommender + shareable links.
   el('recommendInput').addEventListener('input', renderRecommendations);
   el('shareBtn').addEventListener('click', shareSkill);
+  if (el('embedBtn')) el('embedBtn').addEventListener('click', copyEmbed);
+  if (el('remixShareBtn')) el('remixShareBtn').addEventListener('click', shareRemix);
+  if (el('remixClearBtn')) el('remixClearBtn').addEventListener('click', clearRemix);
+  if (el('remixInput')) el('remixInput').addEventListener('input', updateRemixActive);
 
   // Theme is applied + toggled by nav.js (shared across all pages).
 
@@ -545,6 +549,49 @@ function shareSkill() {
   );
 }
 
+// Copy an embed snippet — a "Run this skill" card (rendered by embed.js) for a blog or docs.
+function copyEmbed() {
+  if (!current) return;
+  const snippet = `<div data-pm-skill="${current.name}"></div>\n<script src="https://mohitagw15856.github.io/pm-claude-skills/embed.js" async><\/script>`;
+  navigator.clipboard.writeText(snippet).then(
+    () => { el('shareMsg').textContent = 'Embed snippet copied — paste it into your page HTML.'; },
+    () => { el('shareMsg').textContent = snippet; }
+  );
+}
+
+function updateRemixActive() {
+  const on = !!(el('remixInput') && el('remixInput').value.trim());
+  if (el('remixActive')) el('remixActive').hidden = !on;
+}
+
+function clearRemix() {
+  if (el('remixInput')) el('remixInput').value = '';
+  updateRemixActive();
+  if (el('remixMsg')) el('remixMsg').textContent = '';
+}
+
+// Share a link that reopens this skill with the user's remix (and inputs) applied.
+function shareRemix() {
+  if (!current) return;
+  const rx = el('remixInput') ? el('remixInput').value.trim() : '';
+  if (!rx) { el('remixMsg').textContent = 'Add a remix instruction first.'; return; }
+  const url = new URL(location.href.split('?')[0]);
+  url.searchParams.set('skill', current.name);
+  const values = [...el('inputForm').querySelectorAll('input, textarea')].map((f) => f.value);
+  if (values.some((v) => v.trim())) {
+    try { const p = btoa(unescape(encodeURIComponent(JSON.stringify(values)))); if (p.length < 1800) url.searchParams.set('i', p); } catch (_) {}
+  }
+  let packed;
+  try { packed = btoa(unescape(encodeURIComponent(rx))); } catch (_) { el('remixMsg').textContent = "Couldn't encode that remix."; return; }
+  if (packed.length > 3000) { el('remixMsg').textContent = 'Remix is too long to fit in a link — keep it short.'; return; }
+  url.searchParams.set('remix', packed);
+  const link = url.toString();
+  navigator.clipboard.writeText(link).then(
+    () => { el('remixMsg').textContent = 'Remix link copied — it opens this skill with your instructions applied.'; },
+    () => { el('remixMsg').textContent = link; }
+  );
+}
+
 function applyShareLink() {
   const params = new URLSearchParams(location.search);
   const name = params.get('skill');
@@ -559,6 +606,14 @@ function applyShareLink() {
       const fields = [...el('inputForm').querySelectorAll('input, textarea')];
       fields.forEach((f, i) => { if (values[i] != null) f.value = values[i]; });
     } catch (_) { /* ignore malformed input payloads */ }
+  }
+  const rx = params.get('remix');
+  if (rx && el('remixInput')) {
+    try {
+      el('remixInput').value = decodeURIComponent(escape(atob(rx)));
+      updateRemixActive();
+      if (el('remixBox')) el('remixBox').open = true;
+    } catch (_) { /* ignore malformed remix payloads */ }
   }
 }
 
@@ -817,6 +872,8 @@ function renderRelated(s) {
 function selectSkill(s) {
   current = s;
   recordRecent(s.name);
+  // Reset any remix from a previously-open skill (a shared remix link re-applies it after this).
+  if (el('remixInput')) { el('remixInput').value = ''; updateRemixActive(); if (el('remixMsg')) el('remixMsg').textContent = ''; }
   showHero(false);
   el('gallery').hidden = true;
   el('controls').hidden = true;
@@ -1032,6 +1089,15 @@ ${current.instructions}${ctxBlock}`;
     system += langInstr;
     plainSystem = plainSystem ? plainSystem + langInstr : langInstr.trim();
   }
+  // Remix: layer the user's custom instructions on top of the skill (and the plain side).
+  const remix = el('remixInput') ? el('remixInput').value.trim() : '';
+  if (remix) {
+    const remixInstr = `\n\n## User remix — apply on top of everything above\n${remix}`;
+    system += remixInstr;
+    plainSystem = plainSystem ? plainSystem + remixInstr : remixInstr.trim();
+    if (window.pmTrack) pmTrack('remix/' + current.name);
+  }
+
   // RTL scripts (Arabic, Urdu…) render right-to-left.
   const rtlOpt = el('outputLang') && el('outputLang').selectedOptions[0];
   const dir = rtlOpt && rtlOpt.dataset.rtl ? 'rtl' : 'ltr';

--- a/web/daily.html
+++ b/web/daily.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Daily Challenge — one professional task a day | PM Skills</title>
+<meta name="description" content="A new professional challenge every day — write today's PRD, board minutes, launch plan or postmortem with a real Agent Skill. Build a streak, run it free in your browser, and share your result." />
+<link rel="stylesheet" href="styles.css" />
+<style>
+  .daily { max-width: 720px; margin: 0 auto; padding: 22px 22px 80px; }
+  .streak-row { display: flex; gap: 12px; align-items: center; justify-content: center; margin: 6px 0 18px; flex-wrap: wrap; }
+  .streak { display: inline-flex; align-items: center; gap: 8px; background: var(--panel); border: 1px solid var(--border); border-radius: 999px; padding: 8px 16px; font-weight: 700; }
+  .streak .n { color: var(--accent); font-size: 20px; }
+  .card-day { border: 1px solid var(--border); border-radius: 16px; background: var(--panel); padding: 22px 24px; }
+  .card-day .eyebrow { font-size: 12px; letter-spacing: .04em; text-transform: uppercase; color: var(--accent-2); font-weight: 700; }
+  .card-day h2 { font-size: 23px; margin: 6px 0 4px; }
+  .card-day .skill-chip { display: inline-block; font-size: 12px; font-weight: 700; color: var(--accent-2); background: var(--panel-2); border: 1px solid var(--border); border-radius: 999px; padding: 3px 10px; margin-bottom: 12px; }
+  .card-day .prompt { font-size: 16px; line-height: 1.6; color: var(--text); background: var(--panel-2); border-left: 3px solid var(--accent); border-radius: 8px; padding: 14px 16px; margin: 10px 0 18px; }
+  .cta { display: flex; gap: 12px; flex-wrap: wrap; }
+  .btn { display: inline-block; padding: 11px 18px; border-radius: 10px; font-weight: 700; font-size: 15px; cursor: pointer; border: none; text-decoration: none; }
+  .btn-primary { background: linear-gradient(135deg, #e0855f, #d9605a); color: #1a1207; }
+  .btn-ghost { background: var(--panel-2); border: 1px solid var(--border); color: var(--text); }
+  .msg { min-height: 20px; font-size: 13px; color: var(--accent-2); margin-top: 10px; }
+  .sub { text-align: center; color: #95a0b0; font-size: 14px; margin-top: 22px; }
+  .done-note { color: #6ee7b7; font-weight: 600; }
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
+    <div class="brand-text"><h1>Daily Challenge</h1><p class="tagline">One professional task a day. Build the habit, build a streak.</p></div>
+  </div>
+</header>
+<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+<div class="key-note">🔥 A new challenge every day — write it with a real skill, free in your browser.</div>
+
+<div class="daily">
+  <div class="streak-row">
+    <span class="streak">🔥 <span class="n" id="streakN">0</span>&nbsp;day streak</span>
+    <span class="streak">🏆 <span class="n" id="totalN">0</span>&nbsp;done</span>
+  </div>
+
+  <div class="card-day">
+    <div class="eyebrow" id="dayLabel">Today's challenge</div>
+    <h2 id="chTitle">…</h2>
+    <span class="skill-chip" id="chSkill">skill</span>
+    <div class="prompt" id="chPrompt">Loading today's challenge…</div>
+    <div class="cta">
+      <a class="btn btn-primary" id="runBtn" href="#">▶ Do it now — run in the playground</a>
+      <button class="btn btn-ghost" id="doneBtn" type="button">✓ Mark done</button>
+      <button class="btn btn-ghost" id="shareBtn" type="button">🔗 Share</button>
+    </div>
+    <div class="msg" id="msg"></div>
+  </div>
+
+  <p class="sub" id="comeBack">Come back tomorrow for a new one — miss a day and the streak resets.</p>
+</div>
+
+<script src="nav.js"></script>
+<script>
+(function () {
+  // Curated challenges — each maps to a real skill. Picked deterministically by date,
+  // so everyone gets the same challenge on the same day.
+  var CHALLENGES = [
+    { skill: 'prd-template', title: 'Write a PRD for a referral program', prompt: 'Write a PRD for a referral program that rewards existing B2B users for inviting teammates. Goal: +15% activated signups next quarter. Include problem, goals, users, requirements, success metrics, risks, and rollout.' },
+    { skill: 'board-minutes', title: 'Draft board minutes from rough notes', prompt: 'Draft formal board minutes from these notes: quarterly meeting, 4 directors present, 1 apology, quorum met. Approved prior minutes; reviewed Q3 financials (revenue +12%); approved the annual budget; deferred the fundraising decision. Actions: CFO to send the runway model; CEO to prep a term sheet. Mark unknowns [to confirm].' },
+    { skill: 'incident-postmortem', title: 'Write a blameless postmortem', prompt: 'Write a blameless postmortem for a 45-minute checkout outage caused by a database connection-pool exhaustion after a deploy. Include timeline, impact, root cause, what went well, what went wrong, and corrective actions with owners.' },
+    { skill: 'go-to-market', title: 'Plan a go-to-market for a new feature', prompt: 'Build a go-to-market plan for a new AI-assisted reporting feature in a mid-market analytics product. Audience: RevOps leaders. Cover positioning, target segments, channels, launch tier, enablement, and success metrics.' },
+    { skill: 'executive-update', title: 'Write an exec update on a slipping project', prompt: 'Write a crisp executive update: a key integration project is two weeks behind due to a vendor API delay, mitigation is in progress, and the launch date is at risk. Be honest, lead with the decision needed, and keep it short.' },
+    { skill: 'win-loss-analysis', title: 'Turn deal outcomes into a win/loss report', prompt: 'Run a win/loss analysis: 30 won ($1.2M), 45 lost ($2.4M). Top lost reasons: price (15), missing SSO (10), chose a competitor (8), no decision (7). Wins skew mid-market. Give themes, win rate by cut, controllable vs structural, and actions with owners.' },
+    { skill: 'launch-readiness', title: 'Run a launch-readiness review', prompt: 'Run a launch-readiness review for a payments feature shipping in two weeks. Assess product, docs, support, sales enablement, legal, and marketing. Give a Go / Conditional Go / No-Go with ranked blockers, owners, and deadlines.' },
+    { skill: 'investor-update', title: 'Write a monthly investor update', prompt: 'Write a monthly investor update for a seed-stage SaaS: MRR $85k (+9% MoM), 2 enterprise logos signed, churn ticked up, hiring a founding AE. Include highlights, lowlights, metrics, asks, and runway.' },
+    { skill: 'competitive-analysis', title: 'Do a competitive teardown', prompt: 'Write a competitive analysis of our project-management tool vs two rivals across positioning, pricing, key features, and gaps. End with where we win, where we lose, and two strategic recommendations.' },
+    { skill: 'strategy-memo', title: 'Write a strategy memo on a hard call', prompt: 'Write a strategy memo arguing whether we should move upmarket to enterprise or double down on self-serve SMB. State the recommendation up front, the reasoning, the risks, and what we would stop doing.' },
+    { skill: 'decision-memo', title: 'Write a decision memo', prompt: 'Write a decision memo on whether to build, buy, or partner for a notifications system. Frame the decision, options with trade-offs, a recommendation, and the reversibility of the choice.' },
+    { skill: 'meeting-notes', title: 'Turn messy notes into clean minutes', prompt: 'Turn these messy meeting notes into clean, structured notes with decisions and action items (owner + due date): kickoff for the mobile redesign, debated scope, agreed to ship iOS first, Sarah owns research, launch target end of Q3, open question on the design system.' },
+    { skill: 'product-launch-checklist', title: 'Build a launch checklist', prompt: 'Build a product launch checklist for a new self-serve onboarding flow, covering product, QA, docs, support, marketing, sales, and analytics, with owners and a T-minus timeline.' },
+    { skill: 'sales-demo-script', title: 'Script a value-story product demo', prompt: 'Write a 20-minute first-demo script for an AI reporting tool to a Head of RevOps whose team spends a day a week hand-building reports. Lead with their pain, mark the aha moments, handle "can I trust the numbers?", and close with a next step.' },
+    { skill: 'pricing-page-copy', title: 'Write pricing page copy', prompt: 'Write pricing page copy for a SaaS with Free, Pro ($12/user/mo), Business ($22/user/mo), and Enterprise (custom). Per-seat value metric, 14-day trial, no credit card. Include tier cards, risk reducers, and a pricing FAQ.' },
+    { skill: 'customer-journey-map', title: 'Map a customer journey', prompt: 'Map the customer journey for a new user of a team collaboration app from first touch to habitual use, with stages, actions, thoughts, pain points, and opportunities at each step.' },
+    { skill: 'cs-health-scorecard', title: 'Build an account health scorecard', prompt: 'Build a customer health scorecard for a $60k/yr enterprise account: usage down 20% this quarter, champion left, support tickets rising, renewal in 4 months. Score the risk and recommend a save plan.' },
+    { skill: 'rice-prioritisation', title: 'Prioritise a backlog with RICE', prompt: 'Prioritise these five features with RICE and recommend what to build next quarter: SSO, mobile app, an AI assistant, a public API, and bulk import. Make reasonable assumptions and show the scoring.' },
+    { skill: 'ab-test-planner', title: 'Design an A/B test', prompt: 'Design an A/B test for a new pricing page that we think will lift trial signups. Define the hypothesis, primary and guardrail metrics, sample size assumptions, duration, and how you will decide.' },
+    { skill: 'runbook-writer', title: 'Write an on-call runbook', prompt: 'Write an on-call runbook for "elevated API error rate" on a payments service: detection, triage steps, common causes, mitigations, escalation path, and rollback.' },
+    { skill: 'launch-post', title: 'Write a Show HN / launch post', prompt: 'Write a credible, hype-free launch post for an open-source tool that turns SQL queries into shareable dashboards. Lead with what it does and why it is different, and include title options and a comment-ready first reply.' },
+    { skill: 'readme-writer', title: 'Write a great README', prompt: 'Write a README for a small open-source CLI that formats and lints Markdown files. Include what it is, install, quick start, key options, and a contributing note.' },
+    { skill: 'changelog-writer', title: 'Write a user-facing changelog', prompt: 'Write a user-facing changelog entry for a release that added dark mode, faster search, and fixed a CSV export bug. Group by Added/Improved/Fixed and keep it benefit-led.' },
+    { skill: 'sales-battlecard', title: 'Build a competitive battlecard', prompt: 'Build a sales battlecard for selling our analytics product against a well-known incumbent: our strengths, their strengths, landmines, objection handling, and trap-setting questions.' },
+    { skill: 'sales-enablement-kit', title: 'Build a sales enablement kit', prompt: 'Build a sales enablement kit for a new AI-assisted reporting feature: the pitch, discovery questions, a talk track, a short demo flow, objection handling, and a competitive counter.' },
+    { skill: 'user-interview-synthesis', title: 'Synthesize user interviews', prompt: 'Synthesize these three user-interview takeaways into themes, insights, and recommendations: users love the speed but are confused by onboarding, two asked for integrations, all three disliked the mobile experience.' },
+    { skill: 'board-deck-narrative', title: 'Structure a board deck narrative', prompt: 'Build the storyline and slide structure for a quarterly board deck: strong revenue, a churn problem in SMB, a big enterprise opportunity, and an ask to approve two senior hires.' },
+    { skill: 'one-pager', title: 'Write a one-pager for a new bet', prompt: 'Write a one-pager pitching an internal bet: an AI assistant embedded in our product. Cover the problem, the idea, why now, the expected impact, the risks, and what you need to start.' },
+    { skill: 'voice-of-customer-program', title: 'Design a Voice of Customer program', prompt: 'Design a Voice of Customer program to reduce churn and guide the roadmap, pulling from support tickets, NPS surveys, sales notes, and reviews. Cover sources, taxonomy, cadence, closed-loop routing, and success metrics.' },
+    { skill: 'analyst-relations-brief', title: 'Prep an analyst briefing', prompt: 'Prep a Forrester briefing for a customer data platform. Objective: get on their radar and reposition as activation-first. Give the one message, differentiation with proof, a demo storyline, tough questions with honest answers, and follow-ups.' }
+  ];
+
+  var STORE = 'pm_daily_streak';
+  var PLAYGROUND = 'index.html';
+
+  // Local day index (midnight-based), so "today" is stable for the user's day.
+  function dayNumber(d) { return Math.floor((d.getTime() - d.getTimezoneOffset() * 60000) / 86400000); }
+  var today = dayNumber(new Date());
+  var ch = CHALLENGES[((today % CHALLENGES.length) + CHALLENGES.length) % CHALLENGES.length];
+
+  function load() { try { return JSON.parse(localStorage.getItem(STORE)) || {}; } catch (_) { return {}; } }
+  function save(s) { try { localStorage.setItem(STORE, JSON.stringify(s)); } catch (_) {} }
+
+  var st = load();
+  if (typeof st.streak !== 'number') st = { streak: 0, total: 0, lastDay: null };
+
+  function render() {
+    document.getElementById('streakN').textContent = st.streak || 0;
+    document.getElementById('totalN').textContent = st.total || 0;
+    document.getElementById('chTitle').textContent = ch.title;
+    document.getElementById('chSkill').textContent = ch.skill;
+    document.getElementById('chPrompt').textContent = ch.prompt;
+    // Deep-link into the playground, prefilling the first input with the challenge prompt.
+    var i = btoa(unescape(encodeURIComponent(JSON.stringify([ch.prompt]))));
+    document.getElementById('runBtn').href = PLAYGROUND + '?skill=' + encodeURIComponent(ch.skill) + '&i=' + i;
+    if (st.lastDay === today) {
+      document.getElementById('doneBtn').textContent = '✓ Done today';
+      document.getElementById('doneBtn').disabled = true;
+      document.getElementById('comeBack').innerHTML = '<span class="done-note">Nice — done for today.</span> Come back tomorrow to keep the streak alive.';
+    }
+  }
+
+  function markDone() {
+    if (st.lastDay === today) return;
+    if (st.lastDay === today - 1) st.streak = (st.streak || 0) + 1; // consecutive day
+    else st.streak = 1;                                            // first day or streak broken
+    st.total = (st.total || 0) + 1;
+    st.lastDay = today;
+    save(st);
+    render();
+    document.getElementById('msg').textContent = 'Streak updated — 🔥 ' + st.streak + ' day' + (st.streak === 1 ? '' : 's') + '. See you tomorrow!';
+  }
+
+  // Count a run as completing the challenge.
+  document.getElementById('runBtn').addEventListener('click', function () { markDone(); });
+  document.getElementById('doneBtn').addEventListener('click', markDone);
+  document.getElementById('shareBtn').addEventListener('click', function () {
+    var text = "Today's PM Skills challenge: " + ch.title + ' 🔥 ' + (st.streak || 0) + '-day streak. ' + location.href.split('?')[0];
+    if (navigator.share) { navigator.share({ title: 'PM Skills Daily Challenge', text: text }).catch(function () {}); return; }
+    navigator.clipboard.writeText(text).then(
+      function () { document.getElementById('msg').textContent = 'Copied — share your streak!'; },
+      function () { document.getElementById('msg').textContent = text; }
+    );
+  });
+
+  render();
+})();
+</script>
+</body>
+</html>

--- a/web/i18n.js
+++ b/web/i18n.js
@@ -12,6 +12,7 @@
   var DICT = {
     // ── Nav (shared) ──
     'nav.playground': { en: '▶ Playground', zh: '▶ 技能场' },
+    'nav.daily': { en: '🔥 Daily', zh: '🔥 每日挑战' },
     'nav.jobs': { en: '💼 Job Search', zh: '💼 求职' },
     'nav.journeys': { en: '🧭 Journeys', zh: '🧭 学习路径' },
     'nav.galaxy': { en: '🌌 Galaxy', zh: '🌌 技能星系' },

--- a/web/index.html
+++ b/web/index.html
@@ -127,6 +127,7 @@
         <div id="skillRelated" class="skill-related" hidden></div>
         <button id="sampleBtn" class="ghost sample-btn" type="button" hidden title="See a real, pre-generated example — no key needed">📄 See a sample output — no key needed</button>
         <button id="shareBtn" class="ghost share-btn" type="button" title="Copy a link that opens this skill with these inputs">🔗 Share</button>
+        <button id="embedBtn" class="ghost share-btn" type="button" title="Copy an embed snippet — a 'Run this skill' card for your blog or docs">⧉ Embed</button>
         <span id="shareMsg" class="copy-msg"></span>
       </div>
 
@@ -146,6 +147,18 @@
       </div>
 
       <form id="inputForm" class="input-form"></form>
+
+      <details class="remix" id="remixBox">
+        <summary>✏️ Remix this skill <span id="remixActive" class="remix-active" hidden>· active</span></summary>
+        <p class="remix-note">Add your own instructions on top of this skill — a tone, a format, a must-have section, a language. They're layered onto the skill when you run it, and travel in the Share link so others get your version.</p>
+        <textarea id="remixInput" rows="3" placeholder="e.g. Always write in a warm, plain-English tone. Add a 'Risks' section at the end. Keep it under 400 words."></textarea>
+        <div class="remix-actions">
+          <button id="remixShareBtn" class="ghost" type="button" title="Copy a link that opens this skill with your remix applied">🔗 Share my remix</button>
+          <button id="remixClearBtn" class="ghost" type="button">Clear</button>
+          <span id="remixMsg" class="copy-msg"></span>
+        </div>
+      </details>
+
       <div id="critiqueWrap" class="field" hidden>
         <label for="critiqueInput">Paste your existing draft — it'll be graded against this skill's framework</label>
         <textarea id="critiqueInput" rows="10" placeholder="Paste your PRD / roadmap / exec update / etc. You'll get a rubric score, the specific gaps, and a redline of concrete fixes — graded against the framework this skill encodes."></textarea>

--- a/web/nav.js
+++ b/web/nav.js
@@ -52,6 +52,7 @@
   // stays short. To add/move a tool, edit this list only.
   var NAV = [
     { href: 'index.html', label: '▶ Playground' },
+    { href: 'daily.html', label: '🔥 Daily' },
     { href: 'jobs.html', label: '💼 Job Search' },
     { href: 'hub.html', label: '🧭 Journeys' },
     { href: 'galaxy.html', label: '🌌 Galaxy' },
@@ -85,7 +86,7 @@
   if (file === '' || file === '/') file = 'index.html';
   // Map nav targets to i18n keys (used by i18n.js when the UI language is switched).
   var NAVKEY = {
-    'index.html': 'nav.playground', 'jobs.html': 'nav.jobs', 'hub.html': 'nav.journeys', 'galaxy.html': 'nav.galaxy', 'pro.html': 'nav.pro',
+    'index.html': 'nav.playground', 'daily.html': 'nav.daily', 'jobs.html': 'nav.jobs', 'hub.html': 'nav.journeys', 'galaxy.html': 'nav.galaxy', 'pro.html': 'nav.pro',
     'agent.html': 'nav.agent', 'canvas.html': 'nav.canvas', 'ask.html': 'nav.ask', 'brain.html': 'nav.brain', 'grade.html': 'nav.grade', 'studio.html': 'nav.studio',
     'catalog.html': 'nav.catalog', 'examples.html': 'nav.examples', 'leaderboard.html': 'nav.leaderboard', 'coverage.html': 'nav.coverage',
     'benchmark.html': 'nav.benchmark', 'learn.html': 'nav.learn', 'guide.html': 'nav.guide', 'community.html': 'nav.community',

--- a/web/styles.css
+++ b/web/styles.css
@@ -381,6 +381,14 @@ input:focus, select:focus, textarea:focus { outline: none; box-shadow: 0 0 0 3px
 .file-load:hover { border-color: var(--accent); }
 .gh-issue-input { flex: 1 1 240px; min-width: 200px; font-size: 12.5px; color: var(--text); background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; padding: 6px 11px; }
 .gh-issue-input:focus { outline: none; border-color: var(--accent); }
+.remix { margin: 10px 0 4px; border: 1px solid var(--border); border-radius: 10px; background: var(--panel); padding: 4px 12px; }
+.remix > summary { cursor: pointer; font-size: 13.5px; font-weight: 600; color: var(--accent-2); padding: 6px 0; list-style: none; }
+.remix > summary::-webkit-details-marker { display: none; }
+.remix-active { color: #6ee7b7; font-weight: 700; font-size: 12px; }
+.remix-note { font-size: 12.5px; color: #95a0b0; margin: 4px 0 8px; }
+.remix textarea { width: 100%; box-sizing: border-box; font-size: 13.5px; color: var(--text); background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; resize: vertical; }
+.remix textarea:focus { outline: none; border-color: var(--accent); }
+.remix-actions { display: flex; gap: 10px; align-items: center; margin: 8px 0; flex-wrap: wrap; }
 
 /* ---------- Recommender ---------- */
 .recommend { max-width: 1100px; margin: 18px auto 0; padding: 0 4px; }


### PR DESCRIPTION
Wave 1 of the creative features — **#4 Daily Challenge**, **#7 Embed**, **#8 Remix**. (The Slack/Discord bot #6 follows in its own PR.) Playground-only; no skill/data changes.

## 🔥 #4 — Daily Challenge (`web/daily.html`)
- A new professional task **every day**, picked deterministically by date from a curated set of ~30 challenges, each mapped to a **real skill** (verified against `skills.json`).
- **"Do it now"** deep-links into the playground with the prompt prefilled (reuses the existing `?skill=&i=` share format).
- **Streak + total** tracked in `localStorage` (consecutive-day logic; resets on a miss); **Share** button (Web Share API → clipboard fallback).
- Wired into the nav as **🔥 Daily** with an EN/ZH label.

## ⧉ #7 — Embed
- An **Embed** button (next to Share) copies a ready-to-paste snippet that renders `embed.js`'s "Run this skill" card on any blog or docs page. Turns other people's content into distribution.

## ✏️ #8 — Remix
- **Remix this skill** panel: add your own instructions on top of a skill (tone, format, a must-have section, a language). They layer onto the run — for both generate and critique modes.
- **Share my remix** encodes the remix (+ current inputs) into the link; `applyShareLink` restores it and opens the panel. Remix **resets when you switch skills** so it never leaks between them. Size-guarded so links stay sane.

## Verification
- `web/app.js`, `web/nav.js`, `web/i18n.js` syntax-checked; `daily.html` inline script compiled clean.
- No changes to `skills.json` / generated files — playground-only.
- Deploys automatically via the existing Pages workflow (the whole `web/` folder is the artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_