### PR TITLE
feat(integrations): Slack & Discord /pmskill bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ The same 400 skills reach you through every channel — pick whatever fits your 
 | 🧩 **Browser extension** | A skill picker inside ChatGPT, Claude.ai & Gemini — [`extension/`](extension/) |
 | 🚀 **Raycast / Alfred** | Search every skill from your launcher, then open, run, or install it — [`integrations/raycast/`](integrations/raycast/) · [`integrations/alfred/`](integrations/alfred/) |
 | 🤖 **Custom GPT / Gemini Gem** | Publish the library as a GPT (live Actions API) or a Gem — copy-paste setup in [`integrations/custom-gpt/`](integrations/custom-gpt/) · [`integrations/gemini-gem/`](integrations/gemini-gem/) |
+| 💬 **Slack / Discord** | A `/pmskill` slash command in your team chat — one signature-verified Worker for both — [`integrations/chatops/`](integrations/chatops/) |
 | 🖥️ **IDE rules** | Generated exports for **Cursor, Windsurf, Aider, Cline, Continue, Zed, Roo, Kilo Code** — [`exports/`](exports/) |
 | 🤖 **Agents & answer engines** | [`llms.txt`](https://mohitagw15856.github.io/pm-claude-skills/llms.txt) makes the whole library discoverable & citable |
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -8,5 +8,6 @@ Ways to reach the PM Skills library beyond the CLI, MCP server, and browser play
 | [`alfred/`](alfred/) | Alfred workflow (keyword `pm`) — live skill search | [README](alfred/README.md) |
 | [`custom-gpt/`](custom-gpt/) | Publish the library as a **Custom GPT** in the GPT Store (live Actions API) | [SETUP](custom-gpt/SETUP.md) |
 | [`gemini-gem/`](gemini-gem/) | Publish the library as a **Gemini Gem** (llms.txt knowledge) | [SETUP](gemini-gem/SETUP.md) |
+| [`chatops/`](chatops/) | **Slack & Discord** `/pmskill` slash command — one Cloudflare Worker, signature-verified | [README](chatops/README.md) |
 
 Each of these is a **discovery channel** with its own audience — a store listing, a launcher, or a marketplace — pointing back to the open-source project.

--- a/integrations/chatops/README.md
+++ b/integrations/chatops/README.md
@@ -1,0 +1,60 @@
+# PM Skills — Slack & Discord bot (`/pmskill`)
+
+Bring the library into the places teams actually work. A single Cloudflare Worker serves a **`/pmskill`** slash command on **both** Slack and Discord: type what you need, get the top matching skills with links to run them free in the browser.
+
+```
+/pmskill launch plan
+→ • Go-To-Market — build the storyline, channels, and launch plan …
+  • Launch Readiness — Go / Conditional Go / No-Go with ranked blockers …
+  • Product Launch Checklist — every function, owner, and T-minus step …
+```
+
+It reads the live REST API, so results stay current. Requests are **cryptographically verified** (Slack HMAC, Discord Ed25519) and the Worker **fails closed** — a route without its secret refuses.
+
+## Deploy the Worker (once)
+
+```bash
+cd integrations/chatops
+npx wrangler deploy
+```
+
+Wrangler prints your URL, e.g. `https://pm-skills-chatops.<you>.workers.dev`.
+
+## Slack setup
+
+1. Create an app at **[api.slack.com/apps](https://api.slack.com/apps)** → *From scratch*.
+2. **Basic Information** → copy the **Signing Secret**, then:
+   ```bash
+   npx wrangler secret put SLACK_SIGNING_SECRET
+   ```
+3. **Slash Commands** → *Create New Command*:
+   - **Command:** `/pmskill`
+   - **Request URL:** `https://<worker>/slack`
+   - **Short description:** `Search the PM Skills library`
+   - **Usage hint:** `what you need — e.g. launch plan`
+4. **Install App** to your workspace. Try `/pmskill board minutes`.
+
+> Replies are **ephemeral** (only the requester sees them). To post results to the channel, change `response_type` to `'in_channel'` in `src/index.js`.
+
+## Discord setup
+
+1. Create an app at **[discord.com/developers/applications](https://discord.com/developers/applications)**.
+2. **General Information** → copy the **Public Key**, then:
+   ```bash
+   npx wrangler secret put DISCORD_PUBLIC_KEY
+   ```
+3. Register the slash command (once):
+   ```bash
+   DISCORD_APP_ID=xxx DISCORD_BOT_TOKEN=yyy node register-discord-command.mjs
+   # add DISCORD_GUILD_ID=zzz to test instantly in one server
+   ```
+4. Back in the portal, set **Interactions Endpoint URL** to `https://<worker>/discord` and save (Discord sends a signed PING to verify — the Worker answers it).
+5. In **OAuth2 → URL Generator**, tick `applications.commands`, open the URL, and add the app to your server. Try `/pmskill query: churn`.
+
+## How it works
+
+- `POST /slack` — verifies `X-Slack-Signature` (HMAC-SHA256 over `v0:{ts}:{body}`, 5-minute replay window), parses the command, searches, replies in Slack `mrkdwn`.
+- `POST /discord` — verifies `X-Signature-Ed25519` over `{timestamp}{body}`, answers `PING`, and responds to the command with an ephemeral message.
+- Both call `GET /v1/search?q=…` on the hosted API and link each result to `…/?skill=<name>`.
+
+No data is stored; nothing but an event is ever logged. MIT © Mohit Aggarwal.

--- a/integrations/chatops/register-discord-command.mjs
+++ b/integrations/chatops/register-discord-command.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// One-time: register the /pmskill slash command with your Discord application.
+// Discord slash commands must be registered via the API before they appear.
+//
+// Usage:
+//   DISCORD_APP_ID=xxx DISCORD_BOT_TOKEN=yyy node register-discord-command.mjs
+//
+// Find both in the Discord Developer Portal:
+//   • Application ID → General Information
+//   • Bot token      → Bot → Reset Token
+//
+// Registers globally (can take up to ~1 hour to propagate). To test instantly in
+// one server, set DISCORD_GUILD_ID and it registers to that guild only.
+
+const APP_ID = process.env.DISCORD_APP_ID;
+const TOKEN = process.env.DISCORD_BOT_TOKEN;
+const GUILD_ID = process.env.DISCORD_GUILD_ID;
+
+if (!APP_ID || !TOKEN) {
+  console.error('Set DISCORD_APP_ID and DISCORD_BOT_TOKEN environment variables.');
+  process.exit(1);
+}
+
+const command = {
+  name: 'pmskill',
+  description: 'Search the PM Skills library and get the best-matching skills',
+  options: [
+    {
+      name: 'query',
+      description: 'What you need — e.g. "launch plan", "board minutes", "churn"',
+      type: 3, // STRING
+      required: true,
+    },
+  ],
+};
+
+const url = GUILD_ID
+  ? `https://discord.com/api/v10/applications/${APP_ID}/guilds/${GUILD_ID}/commands`
+  : `https://discord.com/api/v10/applications/${APP_ID}/commands`;
+
+const res = await fetch(url, {
+  method: 'POST',
+  headers: { Authorization: `Bot ${TOKEN}`, 'Content-Type': 'application/json' },
+  body: JSON.stringify(command),
+});
+
+if (res.ok) {
+  console.log(`✓ Registered /pmskill ${GUILD_ID ? `to guild ${GUILD_ID}` : 'globally'}.`);
+} else {
+  console.error(`✗ Failed (${res.status}):`, await res.text());
+  process.exit(1);
+}

--- a/integrations/chatops/src/index.js
+++ b/integrations/chatops/src/index.js
@@ -1,0 +1,145 @@
+// PM Skills ChatOps — a single Cloudflare Worker serving BOTH a Slack slash
+// command (/pmskill) and a Discord slash command (/pmskill). It searches the
+// library via the public REST API and replies with the top matching skills.
+//
+// Requests are verified before anything runs:
+//   • Slack   — HMAC-SHA256 over `v0:{timestamp}:{body}` with SLACK_SIGNING_SECRET
+//   • Discord — Ed25519 over `{timestamp}{body}` with DISCORD_PUBLIC_KEY
+// It FAILS CLOSED: if the relevant secret isn't set, the route refuses (401).
+//
+// Deploy:  cd integrations/chatops && npx wrangler deploy
+// Secrets: npx wrangler secret put SLACK_SIGNING_SECRET
+//          npx wrangler secret put DISCORD_PUBLIC_KEY
+// Then point Slack's slash command at  https://<worker>/slack
+// and Discord's Interactions Endpoint at  https://<worker>/discord
+
+const API = 'https://pm-skills-mcp.pm-claude-skills.workers.dev';
+const SITE = 'https://mohitagw15856.github.io/pm-claude-skills';
+const REPO = 'https://github.com/mohitagw15856/pm-claude-skills';
+
+const enc = (s) => new TextEncoder().encode(s);
+const hex = (buf) => [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, '0')).join('');
+const hexToBytes = (h) => new Uint8Array((h.match(/.{1,2}/g) || []).map((x) => parseInt(x, 16)));
+
+// Constant-time string compare (avoids leaking via early return).
+function safeEqual(a, b) {
+  if (a.length !== b.length) return false;
+  let out = 0;
+  for (let i = 0; i < a.length; i++) out |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return out === 0;
+}
+
+// ---- Shared: search the library via the REST API --------------------------
+async function searchSkills(query, limit = 5) {
+  const q = (query || '').trim();
+  if (!q) return [];
+  const r = await fetch(`${API}/v1/search?q=${encodeURIComponent(q)}`, {
+    cf: { cacheTtl: 300, cacheEverything: true },
+  });
+  if (!r.ok) return [];
+  const j = await r.json();
+  return (j.skills || []).slice(0, limit);
+}
+
+function summarize(s) {
+  return (s.summary || (s.description || '').split(/(?<=[.!?])\s/)[0] || '').slice(0, 140);
+}
+
+// ---- Slack ----------------------------------------------------------------
+async function verifySlack(req, rawBody, secret) {
+  const ts = req.headers.get('x-slack-request-timestamp') || '';
+  const sig = req.headers.get('x-slack-signature') || '';
+  if (!ts || !sig) return false;
+  // Reject stale requests (replay protection): 5-minute window.
+  if (Math.abs(Date.now() / 1000 - Number(ts)) > 300) return false;
+  const key = await crypto.subtle.importKey('raw', enc(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const mac = await crypto.subtle.sign('HMAC', key, enc(`v0:${ts}:${rawBody}`));
+  return safeEqual(`v0=${hex(mac)}`, sig);
+}
+
+async function handleSlack(req, env) {
+  const secret = env.SLACK_SIGNING_SECRET;
+  if (!secret) return json({ text: 'Bot not configured: SLACK_SIGNING_SECRET is missing.' }, 401);
+  const raw = await req.text();
+  if (!(await verifySlack(req, raw, secret))) return new Response('bad signature', { status: 401 });
+
+  const params = new URLSearchParams(raw);
+  const query = params.get('text') || '';
+  const skills = await searchSkills(query);
+
+  if (!skills.length) {
+    return json({
+      response_type: 'ephemeral',
+      text: query
+        ? `No skills matched *${query}*. Browse all 400+ at ${SITE}`
+        : `Usage: \`/pmskill <what you need>\` — e.g. \`/pmskill launch plan\`. Browse: ${SITE}`,
+    });
+  }
+  const lines = skills
+    .map((s) => `• <${SITE}/?skill=${s.name}|*${s.title || s.name}*> — ${summarize(s)}`)
+    .join('\n');
+  return json({
+    response_type: 'ephemeral', // only the requester sees it; change to 'in_channel' to share
+    text: `*Skills for “${query}”*\n${lines}\n\n_Open one to run it free in your browser._`,
+  });
+}
+
+// ---- Discord --------------------------------------------------------------
+async function verifyDiscord(req, rawBody, publicKey) {
+  const sig = req.headers.get('x-signature-ed25519') || '';
+  const ts = req.headers.get('x-signature-timestamp') || '';
+  if (!sig || !ts) return false;
+  try {
+    const key = await crypto.subtle.importKey('raw', hexToBytes(publicKey), { name: 'Ed25519' }, false, ['verify']);
+    return await crypto.subtle.verify({ name: 'Ed25519' }, key, hexToBytes(sig), enc(ts + rawBody));
+  } catch (_) {
+    return false;
+  }
+}
+
+async function handleDiscord(req, env) {
+  const publicKey = env.DISCORD_PUBLIC_KEY;
+  if (!publicKey) return new Response('Bot not configured: DISCORD_PUBLIC_KEY is missing.', { status: 401 });
+  const raw = await req.text();
+  if (!(await verifyDiscord(req, raw, publicKey))) return new Response('bad signature', { status: 401 });
+
+  const body = JSON.parse(raw);
+  if (body.type === 1) return json({ type: 1 }); // PING → PONG
+
+  if (body.type === 2) { // APPLICATION_COMMAND
+    const opt = (body.data?.options || []).find((o) => o.name === 'query');
+    const query = (opt && opt.value) || '';
+    const skills = await searchSkills(query);
+    let content;
+    if (!skills.length) {
+      content = query
+        ? `No skills matched **${query}**. Browse all 400+ at <${SITE}>`
+        : `Usage: \`/pmskill query:<what you need>\`. Browse: <${SITE}>`;
+    } else {
+      const lines = skills.map((s) => `• **${s.title || s.name}** — ${summarize(s)}\n<${SITE}/?skill=${s.name}>`).join('\n');
+      content = `**Skills for “${query}”**\n${lines}`;
+    }
+    return json({ type: 4, data: { content, flags: 64 } }); // 64 = ephemeral
+  }
+  return json({ type: 4, data: { content: 'Unsupported interaction.', flags: 64 } });
+}
+
+// ---- Router ---------------------------------------------------------------
+function json(obj, status = 200) {
+  return new Response(JSON.stringify(obj), { status, headers: { 'content-type': 'application/json' } });
+}
+
+export default {
+  async fetch(req, env) {
+    const url = new URL(req.url);
+    if (req.method === 'POST' && url.pathname === '/slack') return handleSlack(req, env);
+    if (req.method === 'POST' && url.pathname === '/discord') return handleDiscord(req, env);
+    if (url.pathname === '/' || url.pathname === '') {
+      return new Response(
+        `PM Skills ChatOps bot.\nSlack slash command  → POST ${url.origin}/slack\nDiscord interactions → POST ${url.origin}/discord\n\nSource & setup: ${REPO}/tree/main/integrations/chatops\n`,
+        { headers: { 'content-type': 'text/plain' } },
+      );
+    }
+    return new Response('Not found', { status: 404 });
+  },
+};

--- a/integrations/chatops/wrangler.toml
+++ b/integrations/chatops/wrangler.toml
@@ -1,0 +1,17 @@
+name = "pm-skills-chatops"
+main = "src/index.js"
+compatibility_date = "2025-01-01"
+
+# A single Worker serving both the Slack and Discord slash commands.
+#
+# Deploy:
+#   cd integrations/chatops
+#   npx wrangler deploy
+#
+# Then set the signing secrets (fail-closed — a route without its secret refuses):
+#   npx wrangler secret put SLACK_SIGNING_SECRET   # from your Slack app → Basic Information
+#   npx wrangler secret put DISCORD_PUBLIC_KEY      # from your Discord app → General Information
+#
+# Endpoints after deploy (Wrangler prints your <worker>.workers.dev URL):
+#   Slack slash command Request URL    →  https://<worker>/slack
+#   Discord Interactions Endpoint URL  →  https://<worker>/discord


### PR DESCRIPTION
Wave 2 of the creative features — **#6 Slack/Discord bot**. Brings the library into team chat with a `/pmskill` slash command.

## What it is
A single **Cloudflare Worker** (`integrations/chatops/`) serving `/pmskill` on **both** Slack and Discord. Type what you need → the top matching skills, each linking to run it free in the browser. It reads the live `/v1/search` REST API, so results stay current.

```
/pmskill launch plan
→ • Go-To-Market — build the storyline, channels, and launch plan …
  • Launch Readiness — Go / Conditional Go / No-Go …
```

## Security (verified, fail-closed)
- **Slack:** verifies `X-Slack-Signature` (HMAC-SHA256 over `v0:{ts}:{body}`) with a **5-minute replay window**; constant-time compare.
- **Discord:** verifies `X-Signature-Ed25519` over `{timestamp}{body}` with the app public key; answers the `PING` handshake.
- If the relevant secret isn't set, the route **refuses (401)** — nothing runs unsigned. No tokens live in the repo.

## Files
- `src/index.js` — the Worker (router + both handlers + verification).
- `wrangler.toml` — deploy + secret instructions.
- `register-discord-command.mjs` — one-time `/pmskill` command registration.
- `README.md` — step-by-step Slack **and** Discord setup.
- Indexed in `integrations/README.md` + the README "use it anywhere" table.

## Verification
- `src/index.js` and the register script syntax-checked.
- Live `/v1/search` smoke-tested; result formatting falls back to the description's first sentence when a skill has no `summary`.
- Deploy + secrets are the maintainer's step (documented); no repo changes to skills/data.

> This completes the batch: #4 daily + #7 embed + #8 remix shipped in #113; #6 here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_