### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #121)

### DIFF
--- a/commands/adopt-ai-properly.md
+++ b/commands/adopt-ai-properly.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — the org-side AI adoption arc, policy to proof, by chaining 4 skills.
-argument-hint: [the org: size, industry, what AI tools are in use (officially and not), what's worrying leadership]
+argument-hint: "[the org: size, industry, what AI tools are in use (officially and not), what's worrying leadership]"
 ---
 
 Run the **Adopt AI Properly** workflow recipe for: $ARGUMENTS

--- a/commands/brain.md
+++ b/commands/brain.md
@@ -1,6 +1,6 @@
 ---
 description: Set up or use your Professional Brain — init, ingest, recall, or review.
-argument-hint: [init | ingest <thing> | recall <query> | review]
+argument-hint: "[init | ingest <thing> | recall <query> | review]"
 ---
 
 Apply the **professional-brain** skill to: $ARGUMENTS

--- a/commands/close-the-quarter.md
+++ b/commands/close-the-quarter.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — turn the quarter's raw numbers into a leadership story and board deck by chaining 4 skills.
-argument-hint: [the quarter's metrics, wins, and misses]
+argument-hint: "[the quarter's metrics, wins, and misses]"
 ---
 
 Run the **Close the Quarter** workflow recipe for: $ARGUMENTS

--- a/commands/exec-summary.md
+++ b/commands/exec-summary.md
@@ -1,6 +1,6 @@
 ---
 description: Compress a document or update into a crisp executive summary.
-argument-hint: [text, decision, or document to summarise]
+argument-hint: "[text, decision, or document to summarise]"
 ---
 
 Apply the **executive-summary** skill to: $ARGUMENTS

--- a/commands/firm.md
+++ b/commands/firm.md
@@ -1,6 +1,6 @@
 ---
 description: Convene your standing AI staff — memos on every beat, a board session without you, minutes with dissent preserved.
-argument-hint: [optional board agenda — otherwise the staff pick the sharpest open question]
+argument-hint: "[optional board agenda — otherwise the staff pick the sharpest open question]"
 ---
 
 You are the **chief of staff** running a session of the user's standing Firm — a staffed team, not a chatbot. Full concept: the repo's `web/firm.html`; this command is its Claude Code native form, grounded in real files instead of a pasted charter.

--- a/commands/health-scorecard.md
+++ b/commands/health-scorecard.md
@@ -1,6 +1,6 @@
 ---
 description: Build a weighted customer health scorecard for an account.
-argument-hint: [account name + usage/support/commercial signals]
+argument-hint: "[account name + usage/support/commercial signals]"
 ---
 
 Apply the **cs-health-scorecard** skill to: $ARGUMENTS

--- a/commands/land-a-job.md
+++ b/commands/land-a-job.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — go after a specific role end to end by chaining 4 skills: decode the JD, research the company, tailor your application, and prep the interview.
-argument-hint: [the role + company, or paste the job description]
+argument-hint: "[the role + company, or paste the job description]"
 ---
 
 Run the **Land a Job** workflow recipe for: $ARGUMENTS

--- a/commands/launch-a-product.md
+++ b/commands/launch-a-product.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — go from competitive landscape to a fully checklisted launch and press release by chaining 5 skills.
-argument-hint: [the product and who it's for]
+argument-hint: "[the product and who it's for]"
 ---
 
 Run the **Launch a Product** workflow recipe for: $ARGUMENTS

--- a/commands/launch-an-ai-feature.md
+++ b/commands/launch-an-ai-feature.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — take an AI/LLM feature from a probabilistic-aware PRD to a launch-ready model card by chaining 5 skills.
-argument-hint: [the AI feature idea]
+argument-hint: "[the AI feature idea]"
 ---
 
 Run the **Launch an AI Feature** workflow recipe for: $ARGUMENTS

--- a/commands/prd.md
+++ b/commands/prd.md
@@ -1,6 +1,6 @@
 ---
 description: Draft a product requirements document from a feature idea or brief.
-argument-hint: [feature or problem to spec]
+argument-hint: "[feature or problem to spec]"
 ---
 
 Apply the **prd-template** skill to produce a complete PRD for: $ARGUMENTS

--- a/commands/red-team.md
+++ b/commands/red-team.md
@@ -1,6 +1,6 @@
 ---
 description: Stress-test a plan, strategy, PRD, or launch with a room of hostile expert personas before you commit.
-argument-hint: [the plan / doc to pressure-test]
+argument-hint: "[the plan / doc to pressure-test]"
 ---
 
 Apply the **red-team-review** skill to pressure-test: $ARGUMENTS

--- a/commands/repurpose.md
+++ b/commands/repurpose.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — turn one blog post, video, or idea into a full platform-native content pack (thread, LinkedIn, newsletter, carousel, short-form script) with sharp hooks and a thumbnail concept.
-argument-hint: [a URL, a transcript/blog paste, or the core idea]
+argument-hint: "[a URL, a transcript/blog paste, or the core idea]"
 ---
 
 Run the **Repurpose Content** workflow recipe for: $ARGUMENTS

--- a/commands/rescue-an-account.md
+++ b/commands/rescue-an-account.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — diagnose an at-risk customer and build the full save play through to renewal by chaining 4 skills.
-argument-hint: [the account and what's going wrong]
+argument-hint: "[the account and what's going wrong]"
 ---
 
 Run the **Rescue an Account** workflow recipe for: $ARGUMENTS

--- a/commands/retro.md
+++ b/commands/retro.md
@@ -1,6 +1,6 @@
 ---
 description: Run a structured sprint retrospective from notes.
-argument-hint: [what happened this sprint — wins, misses, blockers]
+argument-hint: "[what happened this sprint — wins, misses, blockers]"
 ---
 
 Apply the **retro-analysis** skill to: $ARGUMENTS

--- a/commands/rice.md
+++ b/commands/rice.md
@@ -1,6 +1,6 @@
 ---
 description: Score and rank initiatives with the RICE framework.
-argument-hint: [list of initiatives, or a file/path of them]
+argument-hint: "[list of initiatives, or a file/path of them]"
 ---
 
 Apply the **rice-prioritisation** skill to: $ARGUMENTS

--- a/commands/run-discovery.md
+++ b/commands/run-discovery.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — go from a vague opportunity to validated insight and a prioritised next step by chaining 4 skills.
-argument-hint: [the opportunity or fuzzy question]
+argument-hint: "[the opportunity or fuzzy question]"
 ---
 
 Run the **Run Discovery** workflow recipe for: $ARGUMENTS

--- a/commands/setup-context.md
+++ b/commands/setup-context.md
@@ -1,6 +1,6 @@
 ---
 description: Set up your Skill Memory — a pm-context.md every skill reads so outputs come back tailored to you.
-argument-hint: [optional notes about you/your company to seed it]
+argument-hint: "[optional notes about you/your company to seed it]"
 ---
 
 Set up the user's **Skill Memory** (`pm-context.md`).

--- a/commands/setup-pm-skills.md
+++ b/commands/setup-pm-skills.md
@@ -1,6 +1,6 @@
 ---
 description: Onboard a new user — find out what they do, recommend the right bundles & top skills, and set up a project CONTEXT.md so every skill is tailored to them.
-argument-hint: [optional — your role / what you're working on]
+argument-hint: "[optional — your role / what you're working on]"
 ---
 
 You are onboarding someone to the **PM Skills** library (198 professional Agent Skills across 27 bundles). Goal: get them from "installed" to "got real value" in under two minutes. Context they gave: $ARGUMENTS

--- a/commands/ship-a-feature.md
+++ b/commands/ship-a-feature.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — take a feature idea from fuzzy brief to launch plan by chaining 5 skills.
-argument-hint: [the feature idea or problem]
+argument-hint: "[the feature idea or problem]"
 ---
 
 Run the **Ship a Feature** workflow recipe for: $ARGUMENTS

--- a/commands/ship-an-mcp-server.md
+++ b/commands/ship-an-mcp-server.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — make your product agent-usable by chaining 4 skills, spec to pricing.
-argument-hint: [the product and its API/capabilities, plus what agents will be asked to do]
+argument-hint: "[the product and its API/capabilities, plus what agents will be asked to do]"
 ---
 
 Run the **Ship an MCP Server** workflow recipe for: $ARGUMENTS

--- a/commands/sprint-plan.md
+++ b/commands/sprint-plan.md
@@ -1,6 +1,6 @@
 ---
 description: Plan a sprint with a calibrated, realistic commitment.
-argument-hint: [team size, velocity, backlog items, known absences]
+argument-hint: "[team size, velocity, backlog items, known absences]"
 ---
 
 Apply the **sprint-planning** skill using: $ARGUMENTS


### PR DESCRIPTION
Closes #121.

## Summary

Purely mechanical single-character transform to 21 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (21)

- `commands/prd.md`
- `commands/rice.md`
- `commands/brain.md`
- `commands/retro.md`
- `commands/red-team.md`
- `commands/repurpose.md`
- `commands/land-a-job.md`
- `commands/sprint-plan.md`
- `commands/exec-summary.md`
- `commands/setup-context.md`
- `commands/run-discovery.md`
- `commands/ship-a-feature.md`
- `commands/health-scorecard.md`
- `commands/launch-a-product.md`
- `commands/close-the-quarter.md`
- `commands/rescue-an-account.md`
- `commands/adopt-ai-properly.md`
- `commands/ship-an-mcp-server.md`
- `commands/setup-pm-skills.md`
- `commands/launch-an-ai-feature.md`
- `commands/firm.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
