### PR TITLE
fix: quote argument-hint in grow-a-product.md (the 22nd file #122 missed)

### DIFF
--- a/commands/grow-a-product.md
+++ b/commands/grow-a-product.md
@@ -1,6 +1,6 @@
 ---
 description: Workflow recipe — turn a growth goal into a funnel diagnosis, experiment backlog, retention loop, and lifecycle journeys by chaining 4 skills.
-argument-hint: [the growth goal — e.g. "lift D30 retention for B2B teams"]
+argument-hint: '[the growth goal — e.g. "lift D30 retention for B2B teams"]'
 ---
 
 Run the **Grow a Product** workflow recipe for: $ARGUMENTS


### PR DESCRIPTION
Companion to #121 / #122. That PR quoted `argument-hint` in **21** command files so Copilot CLI ≥1.0.65 parses it as a string instead of a YAML flow-sequence — but `main` has **22** affected files. This closes the last one: `commands/grow-a-product.md`.

## Why it needs a *different* fix
This file's value contains **embedded double quotes**, so #122's bare double-quote wrapping would produce **invalid YAML**:

```yaml
# main (bug): parses as a 1-item list, rejected by strict loaders
argument-hint: [the growth goal — e.g. "lift D30 retention for B2B teams"]

# #122's approach here would BREAK — the inner " terminates the string early:
argument-hint: "[the growth goal — e.g. "lift D30 retention for B2B teams"]"   # YAML ERROR

# this PR — single quotes, safe with embedded double quotes:
argument-hint: '[the growth goal — e.g. "lift D30 retention for B2B teams"]'
```

## Verification
- `yaml.safe_load` on the full frontmatter reports `argument-hint` as **`str`** (`description` intact).
- Confirmed this was the **only** remaining bare `argument-hint` whose value contains a `"` — so single-quoting is the correct, minimal fix.

With #122 + this, all 22 commands load correctly under Copilot CLI ≥1.0.65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_