### PR TITLE
feat(reach): text a skill over SMS / WhatsApp (Twilio worker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ The same 451 skills reach you through every channel — pick whatever fits your 
 | 🚀 **Raycast / Alfred** | Search every skill from your launcher, then open, run, or install it — [`integrations/raycast/`](integrations/raycast/) · [`integrations/alfred/`](integrations/alfred/) |
 | 🤖 **Custom GPT / Gemini Gem** | Publish the library as a GPT (live Actions API) or a Gem — copy-paste setup in [`integrations/custom-gpt/`](integrations/custom-gpt/) · [`integrations/gemini-gem/`](integrations/gemini-gem/) |
 | 💬 **Slack / Discord** | A `/pmskill` slash command in your team chat — one signature-verified Worker for both — [`integrations/chatops/`](integrations/chatops/) |
+| 📱 **Text a skill (SMS/WhatsApp)** | Text a task to a Twilio number, get the drafted artifact back — no app, no browser — [`integrations/twilio/`](integrations/twilio/) |
 | 🖥️ **IDE rules** | Generated exports for **Cursor, Windsurf, Aider, Cline, Continue, Zed, Roo, Kilo Code** — [`exports/`](exports/) |
 | 🤖 **Agents & answer engines** | [`llms.txt`](https://mohitagw15856.github.io/pm-claude-skills/llms.txt) makes the whole library discoverable & citable |
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -9,5 +9,6 @@ Ways to reach the PM Skills library beyond the CLI, MCP server, and browser play
 | [`custom-gpt/`](custom-gpt/) | Publish the library as a **Custom GPT** in the GPT Store (live Actions API) | [SETUP](custom-gpt/SETUP.md) |
 | [`gemini-gem/`](gemini-gem/) | Publish the library as a **Gemini Gem** (llms.txt knowledge) | [SETUP](gemini-gem/SETUP.md) |
 | [`chatops/`](chatops/) | **Slack & Discord** `/pmskill` slash command — one Cloudflare Worker, signature-verified | [README](chatops/README.md) |
+| [`twilio/`](twilio/) | **Text a skill** over SMS / WhatsApp — run a skill from a text, get the result back | [README](twilio/README.md) |
 
 Each of these is a **discovery channel** with its own audience — a store listing, a launcher, or a marketplace — pointing back to the open-source project.

--- a/integrations/twilio/README.md
+++ b/integrations/twilio/README.md
@@ -1,0 +1,42 @@
+# Text a skill (Twilio SMS / WhatsApp)
+
+Run a professional skill by **texting it** — no app, no browser. Meets people where they already are.
+
+```
+You:  board minutes from these notes: Q3 board, 4 directors, approved the budget,
+      deferred the raise. Actions: CFO to send runway model.
+Bot:  MINUTES OF THE BOARD MEETING …
+      — via board-minutes · full: https://…/?skill=board-minutes
+```
+
+- **Auto-routes** the message to the best-fit skill, or force one with a prefix: `prd-template: a referral program for B2B users`.
+- Long results are trimmed with a link to the full run in the browser.
+- Works for **SMS and WhatsApp** (Twilio treats both the same way).
+
+## How it works
+
+A Cloudflare Worker (`src/index.js`) verifies Twilio's request signature (HMAC-SHA1 over the URL + sorted params with your Auth Token — **fails closed** if a secret is missing), finds the skill via the hosted `/v1/search` API, fetches its instructions, runs them on your message with Claude, and returns TwiML so Twilio texts the reply back.
+
+## Setup
+
+1. **Deploy the worker**
+   ```bash
+   cd integrations/twilio
+   npx wrangler deploy
+   ```
+2. **Add the secrets**
+   ```bash
+   npx wrangler secret put ANTHROPIC_API_KEY   # your Claude key — runs the skill
+   npx wrangler secret put TWILIO_AUTH_TOKEN    # Twilio console → Account Info
+   ```
+3. **Point Twilio at it** — buy a number (or use the WhatsApp sandbox), then set
+   **Messaging → "A message comes in"** to `https://<worker>.workers.dev/sms` (HTTP **POST**).
+4. Text your number a task. That's it.
+
+## Notes
+
+- Cost is your Anthropic usage + Twilio's per-message fee. The reply is capped (`SMS_LIMIT`) so a single task stays a few segments.
+- No message content is stored; the worker is stateless.
+- For richer, longer artifacts, the reply always links back to the browser run.
+
+MIT © Mohit Aggarwal

--- a/integrations/twilio/src/index.js
+++ b/integrations/twilio/src/index.js
@@ -1,0 +1,101 @@
+// Text a skill (moonshot: off-web reach). A Cloudflare Worker that receives an
+// SMS or WhatsApp message via Twilio, runs the right skill on it, and texts the
+// result back — no app, no browser.
+//
+//   Text:  "board minutes from these notes: …"   → drafted minutes back
+//   Or force a skill:  "prd-template: a referral program for B2B users"
+//
+// Verifies Twilio's signature (HMAC-SHA1 over the URL + sorted params with your
+// Auth Token) and FAILS CLOSED if a secret is missing.
+//
+// Deploy:  cd integrations/twilio && npx wrangler deploy
+// Secrets: npx wrangler secret put ANTHROPIC_API_KEY
+//          npx wrangler secret put TWILIO_AUTH_TOKEN
+// Then point your Twilio number's "A message comes in" webhook at  https://<worker>/sms
+
+const API = 'https://pm-skills-mcp.pm-claude-skills.workers.dev';
+const SITE = 'https://mohitagw15856.github.io/pm-claude-skills';
+const SMS_LIMIT = 1400; // keep the reply to a few segments; link to the full run
+
+const b64 = (buf) => btoa(String.fromCharCode(...new Uint8Array(buf)));
+const xmlEscape = (s) => String(s).replace(/[<>&'"]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', "'": '&apos;', '"': '&quot;' }[c]));
+
+// Twilio signs: base64( HMAC-SHA1( authToken, fullUrl + concat(sortedKey+value) ) ).
+async function verifyTwilio(url, params, header, token) {
+  if (!header) return false;
+  let data = url;
+  for (const k of [...params.keys()].sort()) data += k + params.get(k);
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(token), { name: 'HMAC', hash: 'SHA-1' }, false, ['sign']);
+  const mac = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data));
+  return b64(mac) === header;
+}
+
+async function searchSkill(q) {
+  const r = await fetch(`${API}/v1/search?q=${encodeURIComponent(q)}`, { cf: { cacheTtl: 300, cacheEverything: true } });
+  if (!r.ok) return null;
+  const j = await r.json();
+  return (j.skills && j.skills[0]) || null;
+}
+
+async function skillBody(name) {
+  const r = await fetch(`${API}/v1/skills/${encodeURIComponent(name)}?format=md`, { cf: { cacheTtl: 300, cacheEverything: true } });
+  return r.ok ? await r.text() : null;
+}
+
+async function runSkill(name, userText, key) {
+  const md = await skillBody(name);
+  if (!md) return null;
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-api-key': key, 'anthropic-version': '2023-06-01' },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1500,
+      system: md + '\n\nYou are replying over SMS — be concise and skip preamble. If required inputs are missing, ask for them in one short line.',
+      messages: [{ role: 'user', content: userText }],
+    }),
+  });
+  if (!res.ok) throw new Error(`anthropic ${res.status}`);
+  const j = await res.json();
+  return (j.content || []).map((c) => c.text || '').join('').trim();
+}
+
+function twiml(msg) {
+  return new Response(`<?xml version="1.0" encoding="UTF-8"?><Response><Message>${xmlEscape(msg)}</Message></Response>`, {
+    headers: { 'content-type': 'text/xml' },
+  });
+}
+
+export default {
+  async fetch(req, env) {
+    const url = new URL(req.url);
+    if (url.pathname !== '/sms' || req.method !== 'POST') return new Response('PM Skills — text a skill. Point your Twilio webhook at POST /sms.', { status: url.pathname === '/' ? 200 : 404 });
+    if (!env.ANTHROPIC_API_KEY || !env.TWILIO_AUTH_TOKEN) return twiml('This bot is not configured yet.');
+
+    const raw = await req.text();
+    const params = new URLSearchParams(raw);
+    if (!(await verifyTwilio(req.url, params, req.headers.get('x-twilio-signature'), env.TWILIO_AUTH_TOKEN))) {
+      return new Response('bad signature', { status: 403 });
+    }
+
+    const bodyText = (params.get('Body') || '').trim();
+    if (!bodyText) return twiml('Text me a task — e.g. "board minutes from these notes: …" — and I\'ll draft it. Or force a skill with "prd-template: …".');
+
+    // Explicit "skill-name: rest" wins; otherwise search for the best-fit skill.
+    let name, input = bodyText;
+    const m = bodyText.match(/^([a-z0-9][a-z0-9-]{2,40}):\s*([\s\S]+)$/i);
+    if (m) { name = m[1].toLowerCase(); input = m[2]; }
+    else { const s = await searchSkill(bodyText); name = s && s.name; }
+    if (!name) return twiml(`Couldn't match a skill. Try naming one, e.g. "meeting-notes: …". Browse: ${SITE}`);
+
+    try {
+      const out = await runSkill(name, input, env.ANTHROPIC_API_KEY);
+      if (!out) return twiml(`Unknown skill "${name}". Browse: ${SITE}`);
+      const link = `${SITE}/?skill=${encodeURIComponent(name)}`;
+      if (out.length <= SMS_LIMIT) return twiml(`${out}\n\n— via ${name} · full: ${link}`);
+      return twiml(`${out.slice(0, SMS_LIMIT)}…\n\n[trimmed] Full version: ${link}`);
+    } catch (e) {
+      return twiml(`Sorry — that failed (${e.message}). Try again, or run it at ${SITE}/?skill=${encodeURIComponent(name)}`);
+    }
+  },
+};

--- a/integrations/twilio/wrangler.toml
+++ b/integrations/twilio/wrangler.toml
@@ -1,0 +1,13 @@
+name = "pm-skills-sms"
+main = "src/index.js"
+compatibility_date = "2025-01-01"
+
+# Text a skill over SMS / WhatsApp via Twilio.
+#
+# Deploy:  cd integrations/twilio && npx wrangler deploy
+# Secrets (fail-closed — the worker refuses without both):
+#   npx wrangler secret put ANTHROPIC_API_KEY   # runs the skill
+#   npx wrangler secret put TWILIO_AUTH_TOKEN    # verifies the request came from Twilio
+#
+# Then in the Twilio console, set your number's "A message comes in" webhook
+# (Messaging) to:  https://<worker>.workers.dev/sms   (HTTP POST)


### PR DESCRIPTION
**#1 of the six off-web surfaces.** Run a professional skill by *texting it* — no app, no browser.

```
You:  board minutes from these notes: Q3 board, 4 directors, approved the budget, deferred the raise…
Bot:  MINUTES OF THE BOARD MEETING … — via board-minutes · full: https://…/?skill=board-minutes
```

## What it is
A Cloudflare Worker (`integrations/twilio/`) that:
- **Verifies Twilio's signature** — HMAC-SHA1 over the URL + sorted params with your Auth Token; **fails closed** if a secret is missing.
- **Routes** the message to the best-fit skill via `/v1/search`, or an explicit `skill-name: …` prefix.
- **Runs** the skill's instructions on the message with Claude and replies via TwiML. Long results are trimmed with a link to the full browser run.
- Works for **SMS and WhatsApp**.

## Verification
- Worker syntax-checked.
- Signature logic **round-trip tested** — a correctly-signed request is accepted, a tampered body is rejected. It's Twilio's standard `RequestValidator` algorithm.
- Deploy + secrets (`ANTHROPIC_API_KEY`, `TWILIO_AUTH_TOKEN`) are the maintainer's step; no tokens in the repo.

## The other five (queued, in order)
📧 Email operator · 🃏 Operator's Deck · 🎮 Firm: the game · 👀 Watch-me-work coach · 📻 Morning-show/newsletter — each its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_