### PR TITLE
feat(reach): email operator — forward a thread, get the artifact back

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ The same 451 skills reach you through every channel — pick whatever fits your 
 | 🤖 **Custom GPT / Gemini Gem** | Publish the library as a GPT (live Actions API) or a Gem — copy-paste setup in [`integrations/custom-gpt/`](integrations/custom-gpt/) · [`integrations/gemini-gem/`](integrations/gemini-gem/) |
 | 💬 **Slack / Discord** | A `/pmskill` slash command in your team chat — one signature-verified Worker for both — [`integrations/chatops/`](integrations/chatops/) |
 | 📱 **Text a skill (SMS/WhatsApp)** | Text a task to a Twilio number, get the drafted artifact back — no app, no browser — [`integrations/twilio/`](integrations/twilio/) |
+| 📧 **Email operator** | Forward a thread to a routing address; the drafted artifact replies in-thread — [`integrations/email/`](integrations/email/) |
 | 🖥️ **IDE rules** | Generated exports for **Cursor, Windsurf, Aider, Cline, Continue, Zed, Roo, Kilo Code** — [`exports/`](exports/) |
 | 🤖 **Agents & answer engines** | [`llms.txt`](https://mohitagw15856.github.io/pm-claude-skills/llms.txt) makes the whole library discoverable & citable |
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -10,5 +10,6 @@ Ways to reach the PM Skills library beyond the CLI, MCP server, and browser play
 | [`gemini-gem/`](gemini-gem/) | Publish the library as a **Gemini Gem** (llms.txt knowledge) | [SETUP](gemini-gem/SETUP.md) |
 | [`chatops/`](chatops/) | **Slack & Discord** `/pmskill` slash command — one Cloudflare Worker, signature-verified | [README](chatops/README.md) |
 | [`twilio/`](twilio/) | **Text a skill** over SMS / WhatsApp — run a skill from a text, get the result back | [README](twilio/README.md) |
+| [`email/`](email/) | **Email operator** — forward a thread, get the drafted artifact back in-thread | [README](email/README.md) |
 
 Each of these is a **discovery channel** with its own audience — a store listing, a launcher, or a marketplace — pointing back to the open-source project.

--- a/integrations/email/.gitignore
+++ b/integrations/email/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/
+*.log

--- a/integrations/email/README.md
+++ b/integrations/email/README.md
@@ -1,0 +1,41 @@
+# Email-native operator
+
+The skills, inside the tool everyone already lives in. **Forward a thread** (or write a fresh mail) to your operator address and the drafted artifact comes back **as a reply, in the same thread** — a PRD, a summary, board minutes, a drafted response.
+
+```
+To:      do@yourdomain.com
+Subject: board-minutes
+Body:    <paste or forward the meeting notes>
+
+← Re: board-minutes
+  MINUTES OF THE BOARD MEETING …
+  — drafted with the "board-minutes" skill · run it yourself: https://…/?skill=board-minutes
+```
+
+- **Name a skill in the subject** (`prd-template`, `meeting-notes`, …) to force it, or just describe the task and it picks the best-fit skill.
+- Replies land **in-thread** using Cloudflare's native email reply — no outbound email service needed.
+
+## How it works
+
+A Cloudflare **Email Worker** (`src/index.js`) parses the incoming message (`postal-mime`), routes it to a skill via the hosted `/v1/search` API, runs the skill's instructions on the body with Claude, builds a reply (`mimetext`), and sends it with `message.reply()`.
+
+## Setup
+
+1. **Install + deploy**
+   ```bash
+   cd integrations/email
+   npm install
+   npx wrangler deploy
+   npx wrangler secret put ANTHROPIC_API_KEY
+   ```
+2. **Turn on Email Routing** — Cloudflare dashboard → your domain → **Email → Email Routing** → enable (this adds the MX/TXT records automatically; your domain must be on Cloudflare).
+3. **Route an address to the Worker** — create a custom address like `do@yourdomain.com` with the action **"Send to a Worker" → `pm-skills-email`**.
+4. Email or forward a thread to that address. The reply comes back.
+
+## Notes
+
+- Stateless; no message content is stored. Cost is your Anthropic usage.
+- The reply always links back to the browser run for the full, editable version.
+- Every draft is footered with a "review before sending / verify `[to confirm]`" reminder.
+
+MIT © Mohit Aggarwal

--- a/integrations/email/package.json
+++ b/integrations/email/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "pm-skills-email",
+  "private": true,
+  "type": "module",
+  "description": "Email-native operator — forward a thread, get the drafted artifact back.",
+  "dependencies": {
+    "mimetext": "^3.0.16",
+    "postal-mime": "^2.2.7"
+  },
+  "devDependencies": {
+    "wrangler": "^3.80.0"
+  },
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev"
+  }
+}

--- a/integrations/email/src/index.js
+++ b/integrations/email/src/index.js
@@ -1,0 +1,90 @@
+// Email-native operator (off-web reach). A Cloudflare Email Worker: forward a
+// thread (or write a fresh mail) to your routing address and get the drafted
+// artifact back as a reply — PRD, summary, board minutes, a drafted response.
+//
+//   Subject:  prd-template
+//   (or just describe the task in the subject/body and it picks a skill)
+//
+// The skill runs on the email body; the reply lands in the same thread.
+//
+// Deploy:  cd integrations/email && npm install && npx wrangler deploy
+// Secret:  npx wrangler secret put ANTHROPIC_API_KEY
+// Then in Cloudflare → Email Routing, route an address (e.g. do@yourdomain)
+// to this Worker.
+import { EmailMessage } from 'cloudflare:email';
+import PostalMime from 'postal-mime';
+import { createMimeMessage } from 'mimetext';
+
+const API = 'https://pm-skills-mcp.pm-claude-skills.workers.dev';
+const SITE = 'https://mohitagw15856.github.io/pm-claude-skills';
+
+async function searchSkill(q) {
+  const r = await fetch(`${API}/v1/search?q=${encodeURIComponent(q)}`, { cf: { cacheTtl: 300, cacheEverything: true } });
+  if (!r.ok) return null;
+  const j = await r.json();
+  return (j.skills && j.skills[0]) || null;
+}
+async function skillBody(name) {
+  const r = await fetch(`${API}/v1/skills/${encodeURIComponent(name)}?format=md`, { cf: { cacheTtl: 300, cacheEverything: true } });
+  return r.ok ? await r.text() : null;
+}
+async function runSkill(md, userText, key) {
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-api-key': key, 'anthropic-version': '2023-06-01' },
+    body: JSON.stringify({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 4000,
+      system: md + '\n\nYou are replying by email. Produce the deliverable directly, no preamble. If required inputs are missing, ask for them briefly at the top.',
+      messages: [{ role: 'user', content: userText.slice(0, 40000) }],
+    }),
+  });
+  if (!res.ok) throw new Error(`anthropic ${res.status}`);
+  const j = await res.json();
+  return (j.content || []).map((c) => c.text || '').join('').trim();
+}
+
+export default {
+  async email(message, env) {
+    const key = env.ANTHROPIC_API_KEY;
+    const parsed = await PostalMime.parse(message.raw);
+    const subject = (parsed.subject || '').trim();
+    const body = (parsed.text || parsed.html || '').replace(/<[^>]+>/g, ' ').trim();
+
+    // Route: an explicit skill name in the subject wins; else search subject+body.
+    let name, footerNote = '';
+    const m = subject.match(/^\s*([a-z0-9][a-z0-9-]{2,40})\s*$/i);
+    if (m) name = m[1].toLowerCase();
+    if (!name) { const s = await searchSkill(subject + ' ' + body.slice(0, 400)); name = s && s.name; }
+
+    let replyText;
+    if (!key) {
+      replyText = 'The email operator is not configured yet (missing ANTHROPIC_API_KEY).';
+    } else if (!name) {
+      replyText = `Couldn't match a skill. Put a skill name in the subject (e.g. "meeting-notes") or describe the task.\n\nBrowse all skills: ${SITE}`;
+    } else {
+      try {
+        const md = await skillBody(name);
+        if (!md) { replyText = `Unknown skill "${name}". Browse: ${SITE}`; }
+        else {
+          const out = await runSkill(md, `${subject ? 'Subject: ' + subject + '\n\n' : ''}${body}`, key);
+          footerNote = `\n\n— drafted with the "${name}" skill · run it yourself: ${SITE}/?skill=${encodeURIComponent(name)}\nReview before sending; verify anything marked [to confirm].`;
+          replyText = out + footerNote;
+        }
+      } catch (e) {
+        replyText = `Sorry — that failed (${e.message}). Try again, or run it at ${SITE}/?skill=${encodeURIComponent(name)}`;
+      }
+    }
+
+    // Reply in-thread using Cloudflare's native email reply.
+    const msg = createMimeMessage();
+    const inReplyTo = message.headers.get('Message-ID');
+    if (inReplyTo) { msg.setHeader('In-Reply-To', inReplyTo); msg.setHeader('References', inReplyTo); }
+    msg.setSender({ name: 'PM Skills', addr: message.to });
+    msg.setRecipient(message.from);
+    msg.setSubject('Re: ' + (subject || 'your request'));
+    msg.addMessage({ contentType: 'text/plain', data: replyText });
+
+    await message.reply(new EmailMessage(message.to, message.from, msg.asRaw()));
+  },
+};

--- a/integrations/email/wrangler.toml
+++ b/integrations/email/wrangler.toml
@@ -1,0 +1,21 @@
+name = "pm-skills-email"
+main = "src/index.js"
+compatibility_date = "2025-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+# Email-native operator. Forward a thread to your routing address, get the
+# drafted artifact back as a reply.
+#
+# Deploy:
+#   cd integrations/email
+#   npm install
+#   npx wrangler deploy
+#   npx wrangler secret put ANTHROPIC_API_KEY
+#
+# Then in the Cloudflare dashboard → your domain → Email → Email Routing:
+#   • enable Email Routing (adds the MX/DNS records)
+#   • create a custom address (e.g. do@yourdomain.com) with action
+#     "Send to a Worker" → pm-skills-email
+#
+# The Worker replies in-thread via Cloudflare's native email reply, so no
+# outbound email service (MailChannels etc.) is required.


### PR DESCRIPTION
**#2 of the six off-web surfaces.** The skills, inside the tool everyone already lives in.

Forward a thread (or write a fresh mail) to your operator address → the drafted artifact replies **in the same thread**.

```
To: do@yourdomain.com   Subject: board-minutes
Body: <forwarded meeting notes>
← Re: board-minutes — MINUTES OF THE BOARD MEETING …
```

## What it is
A Cloudflare **Email Worker** (`integrations/email/`) that:
- Parses the incoming mail with **`postal-mime`**.
- Routes it to a skill — an explicit **skill name in the subject**, else `/v1/search` on subject+body.
- Runs the skill on the body with Claude and **replies in-thread** via Cloudflare's native `message.reply()` (`mimetext`) — **no outbound email service** (MailChannels etc.) required.
- Footers every draft with a "review before sending / verify `[to confirm]`" reminder.

## Setup (in the README)
`npm install && npx wrangler deploy` + `ANTHROPIC_API_KEY` secret, then enable **Email Routing** on your Cloudflare domain and route an address to the Worker.

## Verification
- Worker syntax-checked. Deploy + secret are the maintainer's step; no secrets in the repo.
- Minor: the README "use it anywhere" table row may lightly conflict with #131's row — trivial 1-line resolve if #131 merges first.

Queue remaining: 🃏 Operator's Deck · 🎮 Firm game · 👀 Watch-me-work coach · 📻 Morning-show.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_