### PR TITLE
feat: the Operator's Exam — an open, verifiable credential for professional judgment

### DIFF
--- a/.github/workflows/credentials-check.yml
+++ b/.github/workflows/credentials-check.yml
@@ -1,0 +1,24 @@
+name: Credentials registry check
+
+# Validates credentials/registry.json on any PR that touches the credential
+# files: structure, score bounds, verdict consistency, and — the important
+# part — recomputes each holder's transcript hash so a credential can't claim a
+# score for answers it doesn't actually contain.
+
+on:
+  pull_request:
+    paths:
+      - 'credentials/**'
+      - 'scripts/check-credentials.mjs'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Validate the credentials registry
+        run: node scripts/check-credentials.mjs

--- a/credentials/README.md
+++ b/credentials/README.md
@@ -1,0 +1,35 @@
+# The Operator's Exam — an open, verifiable credential
+
+Most "AI skills" are ungraded. This is the opposite: a public exam of **professional judgment** — five real situations with no single right answer but clearly better and worse ones — and an open credential you can put on your profile and anyone can verify.
+
+Sit it at **[certified.html](https://mohitagw15856.github.io/pm-claude-skills/certified.html)**.
+
+## How it works
+
+1. **Sit the exam.** Five situations (prioritisation under a forced trade-off, catching a lying metric, a hard message, a premortem, an ethical line). You answer in your own words.
+2. **An AI examiner grades each answer** against the fixed rubric in [`exam-1.json`](exam-1.json) — specific, decisive, honest reasoning scores well; vagueness and filler don't. You need **75/100** to pass.
+3. **Pass → mint a credential.** You get a badge and a tamper-evident **credential block**: your handle, per-item scores, total, the exam version, an ISO date, and a SHA-256 hash over the exact text of your answers.
+4. **Claim a permanent entry** by opening a PR/issue that appends your block to [`registry.json`](registry.json).
+
+## The trust model — public record, not a secret key
+
+This is deliberately **not** a gatekept, proctored exam, and it doesn't pretend to be forge-proof by cryptography. The scores are AI-graded in your browser. What makes a credential here *credible* is that it's **public and auditable**:
+
+- Your **answers are published** in the registry — anyone can read them and judge whether the score is fair.
+- CI ([`check-credentials.mjs`](../scripts/check-credentials.mjs)) recomputes the **transcript hash**, so the answers on record are provably the exact ones that were graded — you can't attach a good score to answers you later changed.
+- The rubric is **fixed and public**, so grading is consistent and contestable.
+
+In short: the credential is a durable, honest link to *work you did in public*. That's worth more than an unverifiable claim.
+
+## Verify a credential
+
+Anyone can paste a credential block into the **Verify** tab at [certified.html](https://mohitagw15856.github.io/pm-claude-skills/certified.html) — it recomputes the hash locally and confirms the answers weren't altered, the total matches the item scores, and the verdict matches the pass mark.
+
+## Files
+
+| File | What it is |
+| --- | --- |
+| `exam-1.json` | The exam: items, prompts, rubrics, pass mark. Versioned. |
+| `registry.json` | Public list of credential holders (append via PR). |
+| `../scripts/check-credentials.mjs` | CI validator (shape, bounds, hash recomputation). |
+| `../.github/workflows/credentials-check.yml` | Runs the validator on PRs touching `credentials/**`. |

--- a/credentials/exam-1.json
+++ b/credentials/exam-1.json
@@ -1,0 +1,76 @@
+{
+  "exam": "operator-1",
+  "title": "The Operator's Exam — Professional Judgment, v1",
+  "version": "1.0.0",
+  "published": "2026-07-13",
+  "pass_mark": 75,
+  "max_score": 100,
+  "instructions": "Five situations. Each tests judgment, not knowledge — there is no single right answer, but there are clearly better and worse ones. Answer as you would in the room: concise, specific, and honest about trade-offs. An AI examiner scores each answer against a fixed rubric; you need 75/100 to pass. Your answers become part of your public credential, so anyone can read them and judge for themselves.",
+  "items": [
+    {
+      "id": "prioritization",
+      "points": 20,
+      "title": "The forced trade-off",
+      "prompt": "You lead a team of six. Three things all claim to be P0 this quarter: (a) a reliability fix for a bug hitting ~2% of users daily, (b) the flagship feature your CEO promised a key customer on a call last week, (c) paying down infra debt your staff engineer says will cause an outage 'within a couple of months.' You can seriously staff only one this quarter. Which do you choose, and how do you handle the two you don't? Be specific about what you'd say to the CEO.",
+      "rubric": [
+        "Makes an actual decision and owns it — no 'it depends' hedge.",
+        "Reasons from impact/likelihood/reversibility, not from who shouted loudest.",
+        "Has a concrete, non-dismissive plan for the two deferred items (mitigations, timelines, or a small hedge).",
+        "Handles the CEO commitment with candour — neither blindly obeys nor ignores it; proposes what to tell the customer.",
+        "Names what would change the call (the trigger that flips the priority)."
+      ]
+    },
+    {
+      "id": "metric-integrity",
+      "points": 20,
+      "title": "The number that's lying",
+      "prompt": "A dashboard shows your activation rate 'up 40% MoM' and leadership is thrilled. You suspect it's not real. List the specific ways this number could be true-but-misleading or simply wrong, how you'd check each in an hour, and how you'd communicate your finding to an excited exec without looking like you're raining on the parade.",
+      "rubric": [
+        "Names multiple distinct distortion mechanisms (definition change, denominator shift, seasonality, mix shift, bot/duplicate traffic, survivorship, instrumentation bug).",
+        "Each suspicion has a concrete, fast verification step.",
+        "Distinguishes 'wrong' from 'real but misleading' — shows they understand the difference.",
+        "Communication plan is honest but constructive; leads with what's verified, not with doubt.",
+        "Avoids both credulity and reflexive cynicism."
+      ]
+    },
+    {
+      "id": "hard-message",
+      "points": 20,
+      "title": "The message you don't want to send",
+      "prompt": "A launch you own is slipping three weeks. It's partly your team's miss and partly a dependency that arrived late. Write the actual update (5–8 sentences) you'd send to your VP and the two partner teams affected. It must land the bad news, take appropriate ownership, and keep trust.",
+      "rubric": [
+        "Leads with the news and the new date — no burying it.",
+        "Takes proportionate ownership without scapegoating the dependency or over-grovelling.",
+        "States impact and the concrete recovery plan / new commitment.",
+        "Right altitude and tone for the audience (VP + peers), specific not vague.",
+        "Actually reads like a real message a respected operator would send, not a template."
+      ]
+    },
+    {
+      "id": "premortem",
+      "points": 20,
+      "title": "Kill your own plan",
+      "prompt": "You're about to greenlight a plan you believe in. Run a premortem: it's six months later and the plan failed badly. Give the three most likely specific ways it died (not generic 'bad execution'), the earliest signal you'd have seen for each, and the one cheap thing you'd do now to de-risk the biggest one.",
+      "rubric": [
+        "Failure modes are specific and plausible for a real plan, not boilerplate.",
+        "Ranks by likelihood/impact rather than listing at random.",
+        "Each mode has an early, observable warning signal (a tripwire).",
+        "The de-risking action is cheap, concrete, and actually addresses the top risk.",
+        "Shows genuine adversarial thinking against their own idea, not a strawman."
+      ]
+    },
+    {
+      "id": "ethical-tradeoff",
+      "points": 20,
+      "title": "The line",
+      "prompt": "Growth asks you to ship a change that will measurably lift signups: a pre-checked consent box and a cancel flow that takes five steps. Legal says it's 'probably fine.' The numbers say it works. Do you ship it? Walk through how you decide, what you'd change if anything, and where your actual line is.",
+      "rubric": [
+        "Engages the real tension instead of a comfortable absolute in either direction.",
+        "Separates 'legal' from 'right' and reasons about user trust / long-term cost.",
+        "Proposes a concrete alternative that captures value without the dark pattern, if one exists.",
+        "States a clear personal line and what would make them refuse.",
+        "Considers second-order effects (churn, brand, regulatory, team norms)."
+      ]
+    }
+  ]
+}

--- a/credentials/registry.json
+++ b/credentials/registry.json
@@ -1,0 +1,6 @@
+{
+  "spec": "pm-skills-credentials/1",
+  "exam": "operator-1",
+  "note": "Public registry of Operator's Exam credentials. Each entry is a candidate's own attested result: their GitHub handle, per-item scores, total, the exam version they sat, an ISO timestamp, and a SHA-256 hash over the canonical transcript of their answers. Trust here is by PUBLIC RECORD, not by secret key — the answers are readable in the linked transcript and CI recomputes the hash. To claim a credential: sit the exam at certified.html, pass, and open a PR appending your block below. See README.md.",
+  "holders": []
+}

--- a/scripts/check-credentials.mjs
+++ b/scripts/check-credentials.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Validates credentials/registry.json — the public registry of Operator's Exam
+// credentials. Mirrors the honesty model of the Season/registry checks: the
+// scores are self-reported (AI-graded in the browser), but the ANSWERS are
+// public and the transcript hash is recomputed here, so a credential is
+// tamper-evident — the attested hash must match the exact answers on record.
+//
+//   node scripts/check-credentials.mjs
+import { readFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const exam = JSON.parse(readFileSync(join(root, 'credentials', 'exam-1.json'), 'utf8'));
+const reg = JSON.parse(readFileSync(join(root, 'credentials', 'registry.json'), 'utf8'));
+const errors = [];
+
+if (reg.spec !== 'pm-skills-credentials/1') errors.push('spec must be "pm-skills-credentials/1"');
+if (reg.exam !== exam.exam) errors.push(`registry.exam (${reg.exam}) must match exam.exam (${exam.exam})`);
+if (!Array.isArray(reg.holders)) errors.push('holders must be an array');
+
+const HANDLE_RE = /^[a-zA-Z0-9-]{1,39}$/;
+const maxById = Object.fromEntries(exam.items.map((it) => [it.id, it.points]));
+
+// Canonical transcript — MUST match canonical() in web/certified.html byte-for-byte.
+function canonical(handle, answers) {
+  const parts = [exam.exam, exam.version, String(handle || '').toLowerCase()];
+  for (const it of exam.items) {
+    parts.push(it.id + '\n' + String((answers || {})[it.id] || '').replace(/\r\n/g, '\n').trim());
+  }
+  return parts.join('\n---\n');
+}
+const sha256hex = (s) => createHash('sha256').update(s, 'utf8').digest('hex');
+
+const seen = new Set();
+for (const [i, h] of (reg.holders || []).entries()) {
+  const tag = `holders[${i}] (${h && h.handle || '?'})`;
+  if (!h || typeof h !== 'object') { errors.push(`${tag}: not an object`); continue; }
+  if (!HANDLE_RE.test(h.handle || '')) errors.push(`${tag}: invalid GitHub handle`);
+  if (seen.has((h.handle || '').toLowerCase())) errors.push(`${tag}: duplicate handle`);
+  seen.add((h.handle || '').toLowerCase());
+  if (h.exam !== exam.exam) errors.push(`${tag}: exam must be "${exam.exam}"`);
+  if (typeof h.version !== 'string') errors.push(`${tag}: missing version`);
+  if (isNaN(Date.parse(h.date))) errors.push(`${tag}: date is not a valid ISO timestamp`);
+
+  // Scores: every item present, within 0..max, and total === sum.
+  let sum = 0;
+  for (const it of exam.items) {
+    const v = h.scores && h.scores[it.id];
+    if (typeof v !== 'number' || v < 0 || v > maxById[it.id]) { errors.push(`${tag}: score for "${it.id}" must be 0..${maxById[it.id]}`); }
+    else sum += v;
+  }
+  if (h.total !== sum) errors.push(`${tag}: total (${h.total}) must equal the sum of item scores (${sum})`);
+  const shouldPass = sum >= exam.pass_mark;
+  if ((h.verdict === 'PASS') !== shouldPass) errors.push(`${tag}: verdict "${h.verdict}" inconsistent with total ${sum} vs pass mark ${exam.pass_mark}`);
+  if (h.verdict !== 'PASS') errors.push(`${tag}: only PASS credentials belong in the registry`);
+
+  // Tamper-evidence: the attested hash must match the answers on record.
+  if (!h.answers || typeof h.answers !== 'object') { errors.push(`${tag}: answers object required (so the record is auditable)`); }
+  else {
+    const recomputed = 'sha256-' + sha256hex(canonical(h.handle, h.answers));
+    if (h.transcriptHash !== recomputed) errors.push(`${tag}: transcriptHash does not match the answers (recomputed ${recomputed})`);
+  }
+}
+
+if (errors.length) {
+  console.error(`✗ credentials/registry.json — ${errors.length} problem(s):`);
+  for (const e of errors) console.error('  - ' + e);
+  process.exit(1);
+}
+console.log(`✓ credentials/registry.json OK — ${(reg.holders || []).length} credential(s), all tamper-evident.`);

--- a/web/certified.html
+++ b/web/certified.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>The Operator's Exam — an open, verifiable credential for professional judgment</title>
+<meta name="description" content="Sit five real situations that test judgment, not trivia. An AI examiner scores you against a fixed rubric; pass and you mint an open, publicly-attested credential — a badge and a tamper-evident record anyone can verify. Free, serverless, no gatekeeper." />
+<link rel="stylesheet" href="styles.css" />
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js" integrity="sha384-NNQgBjjuhtXzPmmy4gurS5X7P4uTt1DThyevz4Ua0IVK5+kazYQI1W27JHjbbxQz" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js" integrity="sha384-3HPB1XT51W3gGRxAmZ+qbZwRpRlFQL632y8x+adAqCr4Wp3TaWwCLSTAJJKbyWEK" crossorigin="anonymous"></script>
+<script src="providers.js"></script>
+<style>
+  .ex-wrap { max-width: 820px; margin: 0 auto; padding: 16px 22px 70px; }
+  .ex-lead { color: var(--muted); font-size: 15px; line-height: 1.55; }
+  .ex-id { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin: 14px 0; }
+  .ex-id input { padding: 9px 12px; background: var(--panel); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 14px; }
+  .item { border: 1px solid var(--border); border-radius: 14px; padding: 16px 18px; margin: 14px 0; background: var(--panel); }
+  .item h3 { margin: 0 0 4px; font-size: 16px; } .item .pts { color: var(--muted); font-size: 12px; font-weight: 600; }
+  .item p.prompt { font-size: 14px; line-height: 1.55; margin: 6px 0 10px; }
+  .item textarea { width: 100%; box-sizing: border-box; min-height: 130px; padding: 11px 13px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; color: var(--text); font-family: inherit; font-size: 14px; line-height: 1.5; }
+  .item .score-line { margin-top: 8px; font-size: 13px; }
+  .actions { margin: 16px 0; display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+  /* Result / badge */
+  .result { display: none; border-radius: 16px; padding: 20px 22px; margin: 16px 0; border: 1.5px solid var(--border); background: var(--panel); }
+  .result.show { display: block; }
+  .result.pass { border-color: #3fb950; background: linear-gradient(180deg, rgba(63,185,80,.09), transparent 55%), var(--panel); }
+  .result.fail { border-color: #d29922; background: linear-gradient(180deg, rgba(210,153,34,.08), transparent 55%), var(--panel); }
+  .badge { display: flex; align-items: center; gap: 16px; }
+  .badge .seal { width: 92px; height: 92px; flex: none; }
+  .badge .bmeta h2 { margin: 0 0 2px; font-size: 20px; } .badge .bmeta p { margin: 0; color: var(--muted); font-size: 13px; }
+  .attest { margin-top: 14px; }
+  .attest textarea { width: 100%; box-sizing: border-box; min-height: 120px; font-family: ui-monospace, Menlo, monospace; font-size: 11.5px; padding: 10px 12px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; color: var(--muted); }
+  .scope { border: 1px dashed var(--border); border-radius: 12px; padding: 11px 15px; margin: 16px 0; font-size: 13px; color: var(--muted); }
+  .tabs { display: flex; gap: 8px; margin: 8px 0 16px; }
+  .tabs button { background: var(--panel); border: 1px solid var(--border); color: var(--muted); border-radius: 999px; padding: 6px 14px; cursor: pointer; font-size: 13px; }
+  .tabs button.on { color: var(--text); border-color: var(--accent); }
+  code.h { word-break: break-all; font-size: 11.5px; color: var(--muted); }
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
+    <div class="brand-text"><h1>The Operator's Exam</h1><p class="tagline">An open, verifiable credential for professional judgment.</p></div>
+  </div>
+  <div class="key-area">
+    <select id="provider" title="Model provider"><option value="gemini">Gemini (free key)</option><option value="webllm">In-browser (no key)</option><option value="anthropic">Claude</option><option value="openai">OpenAI</option><option value="ollama">Ollama (local)</option></select>
+    <div class="key-field"><input id="apiKey" type="password" placeholder="sk-ant-… (your Anthropic API key)" autocomplete="off" /><button id="keyToggle" type="button" class="show-toggle">Show</button></div>
+    <select id="model" title="Model"><option value="claude-opus-4-8" selected>Opus 4.8</option><option value="claude-sonnet-4-6">Sonnet 4.6</option><option value="claude-haiku-4-5-20251001">Haiku 4.5</option></select>
+  </div>
+</header>
+<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+<div class="key-note">🔒 Your key + answers stay in your browser and go only to your chosen provider — never to us. You choose whether to publish your result.</div>
+
+<div class="ex-wrap">
+  <div class="tabs">
+    <button id="tabExam" class="on" type="button">Sit the exam</button>
+    <button id="tabVerify" type="button">Verify a credential</button>
+  </div>
+
+  <section id="examView">
+    <p class="ex-lead" id="examLead">Loading the exam…</p>
+    <div class="ex-id">
+      <label for="handle">Your GitHub handle</label>
+      <input id="handle" type="text" placeholder="octocat" autocomplete="off" spellcheck="false" />
+      <span class="pts" id="passNote"></span>
+    </div>
+    <div id="items"></div>
+    <div class="actions">
+      <button id="gradeBtn" class="primary" type="button">Submit for grading</button>
+      <button id="stopBtn" class="ghost" type="button" hidden>Stop</button>
+      <span id="status" class="status"></span>
+    </div>
+
+    <div class="result" id="result">
+      <div class="badge">
+        <div class="seal" id="seal"></div>
+        <div class="bmeta"><h2 id="rTitle"></h2><p id="rSub"></p></div>
+      </div>
+      <article id="feedback" class="output markdown" style="margin-top:14px"></article>
+      <div class="attest" id="attestBox" hidden>
+        <p style="font-size:13px;margin:0 0 6px"><strong>Your credential block</strong> — this is your tamper-evident record. Claim a permanent, public entry:</p>
+        <textarea id="credJson" readonly></textarea>
+        <div class="actions">
+          <button id="copyCred" class="ghost" type="button">Copy block</button>
+          <button id="claimBtn" class="primary" type="button">🎓 Claim it (open a PR)</button>
+          <button id="shareBtn" class="ghost" type="button">𝕏 Share</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="scope">
+      <strong>How the trust works.</strong> This is an <em>open</em> credential: no gatekeeper, no secret key. An AI examiner grades your answers against the fixed rubric in <a href="https://github.com/mohitagw15856/pm-claude-skills/blob/main/credentials/exam-1.json">exam-1.json</a>. When you claim it, your answers become <em>public</em> in the registry and CI recomputes the content hash, so the record is tamper-evident and anyone can re-read and re-judge your work. The credibility is the public transcript, not a claim you can't check.
+    </div>
+  </section>
+
+  <section id="verifyView" hidden>
+    <p class="ex-lead">Paste a credential block below. This page recomputes the SHA-256 over the answers it contains and confirms it matches the attested hash — proof the answers weren't altered after grading.</p>
+    <label for="vJson" style="display:block;font-size:13px;font-weight:600;margin:12px 0 6px">Credential block (JSON)</label>
+    <textarea id="vJson" style="width:100%;box-sizing:border-box;min-height:200px;font-family:ui-monospace,Menlo,monospace;font-size:12px;padding:11px 13px;background:var(--panel);border:1px solid var(--border);border-radius:10px;color:var(--text)"></textarea>
+    <div class="actions"><button id="verifyBtn" class="primary" type="button">Verify</button></div>
+    <div class="result" id="vResult"><article id="vOut" class="output markdown"></article></div>
+  </section>
+</div>
+
+<script>
+const el=(id)=>document.getElementById(id);
+let EXAM=null, controller=null, LASTCRED=null;
+const REPO='https://github.com/mohitagw15856/pm-claude-skills';
+
+init();
+async function init(){
+  PMProviders.initProviderUI();
+  el('keyToggle').addEventListener('click',()=>{const f=el('apiKey');const s=f.type==='password';f.type=s?'text':'password';el('keyToggle').textContent=s?'Hide':'Show';});
+  el('tabExam').addEventListener('click',()=>switchTab('exam'));
+  el('tabVerify').addEventListener('click',()=>switchTab('verify'));
+  el('gradeBtn').addEventListener('click',grade);
+  el('stopBtn').addEventListener('click',()=>controller&&controller.abort());
+  el('copyCred').addEventListener('click',()=>navigator.clipboard.writeText(el('credJson').value));
+  el('claimBtn').addEventListener('click',claim);
+  el('shareBtn').addEventListener('click',share);
+  el('verifyBtn').addEventListener('click',verify);
+  try{ EXAM=await (await fetch('credentials/exam-1.json')).json(); }catch(e){ el('examLead').textContent='Could not load the exam.'; return; }
+  el('examLead').textContent=EXAM.instructions;
+  el('passNote').textContent='Pass mark: '+EXAM.pass_mark+'/'+EXAM.max_score;
+  el('items').innerHTML=EXAM.items.map((it,i)=>`<div class="item"><h3>${i+1}. ${esc(it.title)} <span class="pts">· ${it.points} pts</span></h3><p class="prompt">${esc(it.prompt)}</p><textarea id="ans_${it.id}" placeholder="Your answer…"></textarea><div class="score-line" id="sc_${it.id}"></div></div>`).join('');
+}
+function esc(s){ return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+function switchTab(t){ const ex=t==='exam'; el('examView').hidden=!ex; el('verifyView').hidden=ex; el('tabExam').classList.toggle('on',ex); el('tabVerify').classList.toggle('on',!ex); }
+
+// Canonical transcript → the exact bytes we hash. Must match scripts/check-credentials.mjs.
+function canonical(handle, answers){
+  const parts=[EXAM.exam, EXAM.version, handle.toLowerCase()];
+  for(const it of EXAM.items){ parts.push(it.id+'\n'+String(answers[it.id]||'').replace(/\r\n/g,'\n').trim()); }
+  return parts.join('\n---\n');
+}
+async function sha256hex(str){ const buf=await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str)); return [...new Uint8Array(buf)].map(b=>b.toString(16).padStart(2,'0')).join(''); }
+
+async function grade(){
+  const key=el('apiKey').value.trim(); if(!key) return setStatus('Enter your provider key first.',true);
+  const handle=el('handle').value.trim().replace(/^@/,''); if(!/^[a-zA-Z0-9-]{1,39}$/.test(handle)) return setStatus('Enter a valid GitHub handle.',true);
+  const answers={}; let missing=0;
+  for(const it of EXAM.items){ const v=el('ans_'+it.id).value.trim(); answers[it.id]=v; if(v.length<40) missing++; }
+  if(missing) return setStatus(missing+' answer(s) look too short — give each a real attempt.',true);
+  if(window.pmTrack) pmTrack('exam/submit');
+  const rubric=EXAM.items.map((it,i)=>`ITEM ${it.id} ("${it.title}", max ${it.points}):\nQuestion: ${it.prompt}\nRubric (award points for each met, partial credit fine):\n${it.rubric.map(r=>'  - '+r).join('\n')}\nCandidate answer:\n"""${answers[it.id]}"""`).join('\n\n');
+  const system=`You are a strict, fair examiner for an open professional-judgment credential. Grade each answer ONLY against its rubric. Reward specific, decisive, honest reasoning; penalise vagueness, hedging, and generic filler. Partial credit is expected — most real answers land in the middle. Do not be lenient to be kind; a mediocre answer must score mediocre.
+
+Return EXACTLY this machine-readable block first, then feedback:
+
+SCORES:
+${EXAM.items.map(it=>'- '+it.id+': <0-'+it.points+'>').join('\n')}
+TOTAL: <sum>/${EXAM.max_score}
+VERDICT: <PASS if TOTAL>=${EXAM.pass_mark}, else FAIL>
+
+Then "## Examiner's notes" with one short paragraph per item: what earned points and the single highest-leverage improvement. Be concrete and reference their actual words.`;
+  el('result').className='result'; el('result').classList.add('show'); el('attestBox').hidden=true;
+  el('rTitle').textContent='Grading…'; el('rSub').textContent=''; el('seal').innerHTML=''; el('feedback').innerHTML='';
+  el('gradeBtn').disabled=true; el('stopBtn').hidden=false; controller=new AbortController(); setStatus('The examiner is reading…');
+  try{
+    const acc=await PMProviders.stream({key,model:el('model').value,system,userMessage:rubric,signal:controller.signal,onDelta:(a)=>{ el('feedback').innerHTML=DOMPurify.sanitize(marked.parse(stripScores(a))); }});
+    await finish(acc, handle, answers);
+  }catch(e){ setStatus(e.name==='AbortError'?'Stopped.':(e.message||'Failed.'),true); el('rTitle').textContent='Grading interrupted'; }
+  finally{ el('gradeBtn').disabled=false; el('stopBtn').hidden=true; controller=null; }
+}
+function stripScores(t){ return t.replace(/^SCORES:[\s\S]*?VERDICT:.*$/im,'').trim(); }
+async function finish(acc, handle, answers){
+  const scores={}; let ok=true;
+  for(const it of EXAM.items){ const m=acc.match(new RegExp('^-\\s*'+it.id+':\\s*(\\d{1,3})','im')); if(m){ scores[it.id]=Math.min(it.points,+m[1]); } else { ok=false; } }
+  const total=Object.values(scores).reduce((a,b)=>a+b,0);
+  const verdict= total>=EXAM.pass_mark ? 'PASS':'FAIL';
+  for(const it of EXAM.items){ const s=el('sc_'+it.id); if(s&&scores[it.id]!=null){ s.innerHTML='<strong>'+scores[it.id]+'/'+it.points+'</strong>'; } }
+  const pass=verdict==='PASS';
+  el('result').classList.add(pass?'pass':'fail');
+  el('seal').innerHTML=sealSVG(pass, total);
+  el('rTitle').textContent=pass? 'Certified Operator' : 'Not yet — '+total+'/'+EXAM.max_score;
+  el('rSub').textContent=pass? ('Score '+total+'/'+EXAM.max_score+' · '+EXAM.title) : ('You need '+EXAM.pass_mark+'. Review the notes and re-sit anytime.');
+  setStatus('Done.');
+  if(!pass || !ok){ return; }
+  const date=new Date().toISOString();
+  const hash='sha256-'+await sha256hex(canonical(handle, answers));
+  LASTCRED={ handle, exam:EXAM.exam, version:EXAM.version, date, scores, total, verdict, transcriptHash:hash, answers };
+  el('credJson').value=JSON.stringify(LASTCRED,null,2);
+  el('attestBox').hidden=false;
+}
+function sealSVG(pass, total){
+  const c=pass?'#3fb950':'#d29922';
+  return `<svg viewBox="0 0 92 92" width="92" height="92" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="credential seal">
+    <circle cx="46" cy="46" r="42" fill="none" stroke="${c}" stroke-width="3"/>
+    <circle cx="46" cy="46" r="34" fill="none" stroke="${c}" stroke-width="1" opacity=".5"/>
+    <text x="46" y="40" text-anchor="middle" font-size="9" fill="${c}" font-family="sans-serif" letter-spacing="1">OPERATOR</text>
+    <text x="46" y="60" text-anchor="middle" font-size="20" fill="${c}" font-family="sans-serif" font-weight="700">${pass?total:'—'}</text>
+    <text x="46" y="74" text-anchor="middle" font-size="7" fill="${c}" font-family="sans-serif" opacity=".8">v${EXAM.version}</text>
+  </svg>`;
+}
+function claim(){
+  if(!LASTCRED) return;
+  const title='credential: '+LASTCRED.handle+' — Operator\'s Exam '+LASTCRED.total+'/'+EXAM.max_score;
+  const body='Adding my Operator\'s Exam credential to `credentials/registry.json` (append this object to the `holders` array):\n\n```json\n'+JSON.stringify(LASTCRED,null,2)+'\n```\n\nMy answers are included so anyone can read and re-judge them; CI will recompute the transcript hash.';
+  window.open(REPO+'/issues/new?title='+encodeURIComponent(title)+'&body='+encodeURIComponent(body),'_blank','noopener');
+}
+function share(){
+  if(!LASTCRED) return;
+  const t=`I passed the Operator's Exam — professional judgment, scored ${LASTCRED.total}/${EXAM.max_score}. 🎓\n\nAn open, verifiable credential. Sit it free:`;
+  window.open('https://twitter.com/intent/tweet?text='+encodeURIComponent(t)+'&url='+encodeURIComponent('https://mohitagw15856.github.io/pm-claude-skills/certified.html'),'_blank','noopener');
+}
+async function verify(){
+  const out=el('vOut'); el('vResult').className='result show';
+  let c; try{ c=JSON.parse(el('vJson').value); }catch(e){ el('vResult').classList.add('fail'); out.innerHTML='<strong>❌ Not valid JSON.</strong>'; return; }
+  if(!EXAM){ out.textContent='Exam not loaded.'; return; }
+  const recomputed='sha256-'+await sha256hex(canonical(c.handle||'', c.answers||{}));
+  const match=recomputed===c.transcriptHash;
+  const sum=EXAM.items.reduce((a,it)=>a+(+(c.scores&&c.scores[it.id])||0),0);
+  const totalOk=sum===c.total; const verdictOk=(c.total>=EXAM.pass_mark)===(c.verdict==='PASS');
+  const good=match&&totalOk&&verdictOk;
+  el('vResult').classList.add(good?'pass':'fail');
+  out.innerHTML=DOMPurify.sanitize(marked.parse(
+    (good?'## ✅ Verified\n':'## ⚠️ Does not verify\n')+
+    `- **Handle:** ${esc(c.handle||'—')}\n`+
+    `- **Exam:** ${esc(c.exam||'—')} v${esc(c.version||'—')}\n`+
+    `- **Total:** ${esc(String(c.total))}/${EXAM.max_score} → **${esc(c.verdict||'—')}**\n`+
+    `- **Hash match (answers not altered):** ${match?'✅ yes':'❌ NO'}\n`+
+    `- **Total = sum of item scores:** ${totalOk?'✅ yes':'❌ NO ('+sum+')'}\n`+
+    `- **Verdict consistent with pass mark:** ${verdictOk?'✅ yes':'❌ NO'}\n\n`+
+    (good?'*The answers hash to the attested value — this is the exact work that was graded. Read them yourself to judge the score.*':'*One or more checks failed — treat this credential as unverified.*')
+  ));
+}
+function setStatus(m,err){ const s=el('status'); s.textContent=m; s.className='status'+(err?' err':''); }
+</script>
+<script src="i18n.js"></script>
+<script src="nav.js"></script>
+</body>
+</html>

--- a/web/nav.js
+++ b/web/nav.js
@@ -64,6 +64,7 @@
       ['live.html', '🎙️ Live Meeting'],
       ['morningshow.html', '📻 Morning Show'],
       ['consult.html', '💬 Consultant Mode'],
+      ['certified.html', '🎓 Operator\'s Exam'],
     ] },
     { group: 'Tools', items: [
       ['firm.html', '🏢 The Firm'],


### PR DESCRIPTION
## The Operator's Exam 🎓

Turns the arena machinery (Gym / Gauntlet / Season) into an actual **credential**. Five real situations test **professional judgment** — a forced trade-off, a metric that's lying, a hard message, a premortem, an ethical line. An AI examiner grades each answer against a **fixed public rubric**; pass **75/100** and you mint a badge + a tamper-evident credential you can put on your profile and anyone can verify.

This reframes the project from "a skill library" toward *the open standard that certifies judgment in the AI era* — a category nobody owns yet.

### The trust model — public record, not a secret key
Deliberately **not** a gatekept, proctored, crypto-forge-proof exam (it doesn't pretend to be). Scores are AI-graded in your browser. What makes a credential credible here is that it's **public and auditable**, exactly like the Season/registry honesty model:
- Your **answers are published** in the registry — anyone can read them and judge whether the score is fair.
- CI **recomputes the transcript hash**, so a credential provably links its score to the exact answers that earned it (you can't attach a good score to answers you later changed).
- The rubric is **fixed and public**, so grading is consistent and contestable.

### What's in it
- **`web/certified.html`** — sit the exam + a **Verify** tab, on the shared `PMProviders` layer (key + answers never leave the browser). Badge SVG, credential block, claim-by-PR flow, share.
- **`credentials/exam-1.json`** — the versioned exam (items, prompts, rubrics, pass mark). **`credentials/registry.json`** — the public holders list (starts empty).
- **`scripts/check-credentials.mjs`** — CI validator: shape, score bounds, verdict consistency, and **transcript-hash recomputation**. Its `canonical()` matches the browser byte-for-byte — round-trip and tamper cases tested locally (a single altered character fails the hash).
- **`.github/workflows/credentials-check.yml`** — runs the validator on PRs touching `credentials/**`.
- `credentials/README.md` + a **🆕 New** nav entry.

### Notes
- No new dependencies; reuses SRI-pinned CDN scripts + `providers.js`; hashing via SubtleCrypto (browser) / `node:crypto` (CI).
- Fully client-side page; deploys via the existing GitHub Pages `web/**` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_