### PR TITLE
fix(exports): show the correct file extension in generated README hints

### DIFF
--- a/exports/aider/README.md
+++ b/exports/aider/README.md
@@ -3,7 +3,7 @@
 > Auto-generated from `skills/*/SKILL.md` by `scripts/build-exports.mjs`.
 > **Do not edit these files by hand** — edit the source skill and regenerate.
 
-466 skills exported. Copy a `.mdc rule` into the tool to use it.
+466 skills exported. Copy a `.md rule` into the tool to use it.
 
 | Skill | Bundle | Path |
 |---|---|---|

--- a/exports/cline/README.md
+++ b/exports/cline/README.md
@@ -3,7 +3,7 @@
 > Auto-generated from `skills/*/SKILL.md` by `scripts/build-exports.mjs`.
 > **Do not edit these files by hand** — edit the source skill and regenerate.
 
-466 skills exported. Copy a `.mdc rule` into the tool to use it.
+466 skills exported. Copy a `.md rule` into the tool to use it.
 
 | Skill | Bundle | Path |
 |---|---|---|

--- a/exports/continue/README.md
+++ b/exports/continue/README.md
@@ -3,7 +3,7 @@
 > Auto-generated from `skills/*/SKILL.md` by `scripts/build-exports.mjs`.
 > **Do not edit these files by hand** — edit the source skill and regenerate.
 
-466 skills exported. Copy a `.mdc rule` into the tool to use it.
+466 skills exported. Copy a `.md rule` into the tool to use it.
 
 | Skill | Bundle | Path |
 |---|---|---|

--- a/exports/kilocode/README.md
+++ b/exports/kilocode/README.md
@@ -3,7 +3,7 @@
 > Auto-generated from `skills/*/SKILL.md` by `scripts/build-exports.mjs`.
 > **Do not edit these files by hand** — edit the source skill and regenerate.
 
-466 skills exported. Copy a `.mdc rule` into the tool to use it.
+466 skills exported. Copy a `.md rule` into the tool to use it.
 
 | Skill | Bundle | Path |
 |---|---|---|

--- a/exports/obsidian/README.md
+++ b/exports/obsidian/README.md
@@ -3,7 +3,7 @@
 > Auto-generated from `skills/*/SKILL.md` by `scripts/build-exports.mjs`.
 > **Do not edit these files by hand** — edit the source skill and regenerate.
 
-466 skills exported. Copy a `.mdc rule` into the tool to use it.
+466 skills exported. Copy a `.md rule` into the tool to use it.
 
 | Skill | Bundle | Path |
 |---|---|---|

--- a/exports/roo/README.md
+++ b/exports/roo/README.md
@@ -3,7 +3,7 @@
 > Auto-generated from `skills/*/SKILL.md` by `scripts/build-exports.mjs`.
 > **Do not edit these files by hand** — edit the source skill and regenerate.
 
-466 skills exported. Copy a `.mdc rule` into the tool to use it.
+466 skills exported. Copy a `.md rule` into the tool to use it.
 
 | Skill | Bundle | Path |
 |---|---|---|

--- a/exports/windsurf/README.md
+++ b/exports/windsurf/README.md
@@ -3,7 +3,7 @@
 > Auto-generated from `skills/*/SKILL.md` by `scripts/build-exports.mjs`.
 > **Do not edit these files by hand** — edit the source skill and regenerate.
 
-466 skills exported. Copy a `.mdc rule` into the tool to use it.
+466 skills exported. Copy a `.md rule` into the tool to use it.
 
 | Skill | Bundle | Path |
 |---|---|---|

--- a/exports/zed/README.md
+++ b/exports/zed/README.md
@@ -3,7 +3,7 @@
 > Auto-generated from `skills/*/SKILL.md` by `scripts/build-exports.mjs`.
 > **Do not edit these files by hand** — edit the source skill and regenerate.
 
-466 skills exported. Copy a `.mdc rule` into the tool to use it.
+466 skills exported. Copy a `.md rule` into the tool to use it.
 
 | Skill | Bundle | Path |
 |---|---|---|

--- a/scripts/build-exports.mjs
+++ b/scripts/build-exports.mjs
@@ -215,8 +215,17 @@ function planPlatform(key, platform, skills) {
     parts.push(skill.name, fileNameFor(platform, skill));
     files.set(join(...parts), platform.render(skill));
   }
-  // Generated index for the platform.
-  const fileHint = typeof platform.file === 'function' ? '.mdc rule' : platform.file;
+  // Generated index for the platform. Derive the extension from an actual
+  // rendered filename so the hint matches what each platform emits (only
+  // `cursor` uses `.mdc`; every other function-based platform uses `.md`).
+  let fileHint;
+  if (typeof platform.file === 'function') {
+    const sample = skills[0] ? platform.file(skills[0]) : '';
+    const ext = sample.slice(sample.lastIndexOf('.'));
+    fileHint = ext ? `${ext} rule` : 'rule';
+  } else {
+    fileHint = platform.file;
+  }
   const index = [
     `# ${platform.label}`,
     '',


### PR DESCRIPTION
## What does this PR add or change?

Fixes the auto-generated `README.md` in each `exports/<platform>/` folder so it advertises the actual file extension that platform emits, instead of always saying `.mdc rule`.

## Type of change

- [x] Bug fix (build script produces incorrect docs)
- [x] Documentation update (regenerated 8 export READMEs)

## Related issue

Closes #143

---

## The bug

`scripts/build-exports.mjs:219` computed the README's "Copy a … into the tool" hint like this:

```js
const fileHint = typeof platform.file === 'function' ? '.mdc rule' : platform.file;
```

That was correct for `cursor` (the only platform whose `file` function returns `.mdc`) but wrong for every other platform whose `file` field is a function — `windsurf`, `aider`, `cline`, `continue`, `zed`, `roo`, `kilocode`, `obsidian` — because they all return `.md`. The generated README for those 8 platforms said, e.g.:

> `466 skills exported. Copy a `.mdc rule` into the tool to use it.`

…while the folder only contained `.md` files. Even the heading gave it away — `# Windsurf — workspace rule (.md)` above `Copy a `.mdc rule` …`.

## The fix

Derive the extension from an actually rendered filename. If `platform.file` is a function, call it against the first skill and take the extension off the returned name; otherwise use the fixed filename as before.

```js
let fileHint;
if (typeof platform.file === 'function') {
  const sample = skills[0] ? platform.file(skills[0]) : '';
  const ext = sample.slice(sample.lastIndexOf('.'));
  fileHint = ext ? `${ext} rule` : 'rule';
} else {
  fileHint = platform.file;
}
```

This keeps a single source of truth (the platform registry) and prevents the hint from drifting again if a new function-file platform is added later.

## Verification

```
$ node scripts/build-exports.mjs
Wrote 5138 files — 466 skills × 11 platform(s): chatgpt, gemini, cursor, windsurf, aider, cline, continue, zed, roo, kilocode, obsidian.

$ node scripts/build-exports.mjs --check
Exports are up to date (466 skills × 11 platform(s)).

$ sed -n '6p' exports/windsurf/README.md exports/aider/README.md exports/cursor/README.md exports/kilocode/README.md exports/chatgpt/README.md
466 skills exported. Copy a `.md rule` into the tool to use it.
466 skills exported. Copy a `.md rule` into the tool to use it.
466 skills exported. Copy a `.mdc rule` into the tool to use it.
466 skills exported. Copy a `.md rule` into the tool to use it.
466 skills exported. Copy a `SYSTEM_PROMPT.md` into the tool to use it.
```

Cursor still reads `.mdc rule` (correct); the eight `.md`-emitting platforms now read `.md rule`; the fixed-filename platforms (`chatgpt`, `gemini`) are unchanged.

## Anything else?

- 9 files changed: one script + eight regenerated READMEs. No content changes to any actual `.md` / `.mdc` skill file.
- The three PRs in this bug hunt (#143, #144, #145) are all independent — they touch different files.