### PR TITLE
fix(cli): include kilocode in `list` and derive agents from the registry

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -226,12 +226,13 @@ function add(opts) {
 
 function list() {
   console.log('Supported agents and default targets:\n');
-  for (const a of ['claude', 'hermes', 'codex', 'openclaw', 'cursor', 'windsurf', 'aider']) {
+  // Derive from the registries above so this can't drift from what `add` accepts.
+  for (const a of [...NATIVE, ...Object.keys(RULEFILE)]) {
     console.log(`  ${a.padEnd(9)} ${defaultTarget(a)}`);
   }
   console.log('\nNative SKILL.md agents: claude, hermes, codex, openclaw (install skill folders).');
-  console.log('Claude also gets subagents + slash commands. Cursor/Windsurf install rule files;');
-  console.log('Aider installs conventions you load with "aider --read".');
+  console.log('Claude also gets subagents + slash commands. Cursor / Windsurf / Kilo Code install');
+  console.log('rule files; Aider installs conventions you load with "aider --read".');
   console.log(`\n${STAR}`);
 }
 


### PR DESCRIPTION
## What does this PR add or change?

`npx pm-claude-skills list` now shows all 8 supported agents (including `kilocode`), and it derives the list from the CLI's own registries so it can't drift from what `add` actually accepts.

## Type of change

- [x] Bug fix (CLI output missing a supported agent)

## Related issue

Closes #144

---

## The bug

`bin/cli.mjs` treats `kilocode` as a fully supported rule-file agent:

- `RULEFILE` map (line 29): `kilocode: '.md'`
- `defaultTarget()` (line 38): `kilocode: join(process.cwd(), '.kilocode', 'rules')`
- `add`'s invalid-agent error (line 159) lists it: `"…cursor, windsurf, aider, kilocode."`
- `scripts/install.sh --list` shows it
- `CONTRIBUTING.md` calls out `exports/kilocode/` as the worked example for adding a new export target

…but `list()` iterated a hardcoded 7-agent array that dropped it:

```js
for (const a of ['claude', 'hermes', 'codex', 'openclaw', 'cursor', 'windsurf', 'aider']) {
```

Users running `list` would never discover Kilo Code support through the CLI.

## The fix

Iterate `[...NATIVE, ...Object.keys(RULEFILE)]` so the two sources of truth stay in sync automatically, and mention Kilo Code alongside Cursor/Windsurf in the trailing description.

## Verification

Before:

```
$ node bin/cli.mjs list
Supported agents and default targets:

  claude    ~/.claude/skills
  hermes    ~/.hermes/skills
  codex     ~/.codex/skills
  openclaw  ~/.openclaw/skills
  cursor    ./.cursor/rules
  windsurf  ./.windsurf/rules
  aider     ./.aider/skills

Native SKILL.md agents: claude, hermes, codex, openclaw (install skill folders).
Claude also gets subagents + slash commands. Cursor/Windsurf install rule files;
Aider installs conventions you load with "aider --read".
```

After:

```
$ node bin/cli.mjs list
Supported agents and default targets:

  claude    ~/.claude/skills
  hermes    ~/.hermes/skills
  codex     ~/.codex/skills
  openclaw  ~/.openclaw/skills
  cursor    ./.cursor/rules
  windsurf  ./.windsurf/rules
  aider     ./.aider/skills
  kilocode  ./.kilocode/rules

Native SKILL.md agents: claude, hermes, codex, openclaw (install skill folders).
Claude also gets subagents + slash commands. Cursor / Windsurf / Kilo Code install
rule files; Aider installs conventions you load with "aider --read".
```

Matches `bash scripts/install.sh --list` again.

## Anything else?

- Single-file, 4-line change; no data regeneration required.
- Companion PRs from the same audit — #146 (`build-exports` README hint) and the postinstall count fix — touch different files and are independent.