### PR TITLE
fix(postinstall): count skills at install time instead of hardcoding 232

### DIFF
--- a/bin/postinstall.mjs
+++ b/bin/postinstall.mjs
@@ -3,17 +3,37 @@
 // `npm fund` wondering what to do. This package is a CLI, not a library — there's
 // nothing to import; you RUN it. Must never fail an install: everything is wrapped
 // and it always exits 0.
+import { readdirSync, existsSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 try {
   // Stay quiet in CI / non-interactive installs (e.g. this repo's own `npm ci`),
   // where a marketing banner is just noise.
   if (process.env.CI || !process.stdout.isTTY) process.exit(0);
 
+  // Count the shipped skills at install time so the banner can't drift from
+  // the actual library. Wrapped in try/catch to preserve the "never fail an
+  // install over a banner" contract; falls back to a countless message.
+  const skillCount = (() => {
+    try {
+      const skillsDir = join(dirname(dirname(fileURLToPath(import.meta.url))), 'skills');
+      if (!existsSync(skillsDir)) return null;
+      return readdirSync(skillsDir).filter((n) => {
+        try { return existsSync(join(skillsDir, n, 'SKILL.md')) && statSync(join(skillsDir, n)).isDirectory(); }
+        catch { return false; }
+      }).length;
+    } catch { return null; }
+  })();
+
   const B = (s) => `\x1b[1m${s}\x1b[0m`;
   const D = (s) => `\x1b[2m${s}\x1b[0m`;
   const A = (s) => `\x1b[38;5;208m${s}\x1b[0m`; // accent
+  const headline = skillCount
+    ? `  ✅ pm-claude-skills installed — ${skillCount} professional Agent Skills.`
+    : `  ✅ pm-claude-skills installed.`;
   const lines = [
     '',
-    A('  ✅ pm-claude-skills installed — 232 professional Agent Skills.'),
+    A(headline),
     '',
     "  This is a CLI, not a library — nothing to import. Here's what to run:",
     '',


### PR DESCRIPTION
## What does this PR add or change?

Replaces the hardcoded `"232 professional Agent Skills"` in the postinstall banner with a count computed from the actual `skills/` folder at install time.

## Type of change

- [x] Bug fix (installation banner shows a wrong count)

## Related issue

Closes #145

---

## The bug

`bin/postinstall.mjs:16` shipped a stale hardcoded number:

```js
A('  ✅ pm-claude-skills installed — 232 professional Agent Skills.'),
```

The library now ships **466 skills** — the same number `package.json`'s description reports. So the very first thing every `npm i pm-claude-skills` user saw was the library undercounted by more than half.

## The fix

Count the shipped skills at install time. `skills/` is included in `package.json`'s `files` array, so it's always present in the installed tree. The count is wrapped in a try/catch that returns `null` on any failure; the banner then falls back to a countless headline. This preserves the file's original contract — *"Must never fail an install: everything is wrapped and it always exits 0."*

```js
const skillCount = (() => {
  try {
    const skillsDir = join(dirname(dirname(fileURLToPath(import.meta.url))), 'skills');
    if (!existsSync(skillsDir)) return null;
    return readdirSync(skillsDir).filter((n) => {
      try { return existsSync(join(skillsDir, n, 'SKILL.md')) && statSync(join(skillsDir, n)).isDirectory(); }
      catch { return false; }
    }).length;
  } catch { return null; }
})();
```

## Verification

Ran the postinstall directly against a TTY:

```
$ node bin/postinstall.mjs
  ✅ pm-claude-skills installed — 466 professional Agent Skills.

  This is a CLI, not a library — nothing to import. Here's what to run:
  …
```

Matches `ls skills | wc -l` (466) and `find skills -name SKILL.md | wc -l` (466). The CI-quiet path (`process.env.CI || !process.stdout.isTTY`) still short-circuits before doing any work.

## Anything else?

- Companion PRs from the same audit — #146 (`build-exports` README hint) and #147 (`cli list` omits kilocode) — touch different files and are independent.
- The `README.md` and repo description also carry stale counts (400) but those aren't user-facing at install time; scoped this PR to the banner only.