### PR TITLE
feat: beyond the document — meeting packets, own-data, sites & interactive exports (PR B of 2)

### DIFF
--- a/web/data.html
+++ b/web/data.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Bring your own data — run a skill grounded in your real numbers, export in any language</title>
+<meta name="description" content="Import a CSV, a pasted table, or a published Google Sheet, and run any skill grounded in your real data — not a made-up example. Then export the result as Word/PDF/Excel, and translate the finished artifact into another language in one click. All in your browser." />
+<link rel="stylesheet" href="styles.css" />
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js" integrity="sha384-NNQgBjjuhtXzPmmy4gurS5X7P4uTt1DThyevz4Ua0IVK5+kazYQI1W27JHjbbxQz" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js" integrity="sha384-3HPB1XT51W3gGRxAmZ+qbZwRpRlFQL632y8x+adAqCr4Wp3TaWwCLSTAJJKbyWEK" crossorigin="anonymous"></script>
+<script src="providers.js"></script>
+<script src="export-doc.js"></script>
+<style>
+  .dt-wrap { max-width: 840px; margin: 0 auto; padding: 16px 22px 70px; }
+  .dt-lead { color: var(--muted); font-size: 15px; line-height: 1.55; }
+  .card { border: 1px solid var(--border); border-radius: 14px; padding: 14px 16px; margin: 12px 0; background: var(--panel); }
+  label.fld { display: block; font-size: 13px; font-weight: 600; margin: 8px 0 5px; }
+  .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+  select, input[type=text] { padding: 9px 12px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 14px; }
+  textarea { width: 100%; box-sizing: border-box; padding: 12px 14px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; color: var(--text); font-family: inherit; font-size: 14px; line-height: 1.5; }
+  #data { min-height: 120px; font-family: ui-monospace, Menlo, monospace; font-size: 12.5px; }
+  #instruction { min-height: 70px; }
+  .actions { margin: 12px 0; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+  .exp-btn { background: var(--panel-2); border: 1px solid var(--border); color: var(--text); border-radius: 8px; padding: 8px 12px; cursor: pointer; font-size: 13px; }
+  .exp-btn:hover { border-color: var(--accent); }
+  .grid { overflow-x: auto; } table.prev { border-collapse: collapse; font-size: 12px; margin-top: 8px; } table.prev td, table.prev th { border: 1px solid var(--border); padding: 4px 8px; white-space: nowrap; } table.prev th { background: var(--panel-2); }
+  .mini { font-size: 12px; color: var(--muted); }
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
+    <div class="brand-text"><h1>Bring your own data</h1><p class="tagline">Ground a skill in your real numbers. Export in any language.</p></div>
+  </div>
+  <div class="key-area">
+    <select id="provider" title="Model provider"><option value="gemini">Gemini (free key)</option><option value="webllm">In-browser (no key)</option><option value="anthropic">Claude</option><option value="openai">OpenAI</option><option value="ollama">Ollama (local)</option></select>
+    <div class="key-field"><input id="apiKey" type="password" placeholder="sk-ant-… (your Anthropic API key)" autocomplete="off" /><button id="keyToggle" type="button" class="show-toggle">Show</button></div>
+    <select id="model" title="Model"><option value="claude-opus-4-8">Opus 4.8</option><option value="claude-sonnet-4-6" selected>Sonnet 4.6</option><option value="claude-haiku-4-5-20251001">Haiku 4.5</option></select>
+  </div>
+</header>
+<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+<div class="key-note">🔒 Your key + data stay in your browser and go only to your chosen provider — never to us.</div>
+
+<div class="dt-wrap">
+  <p class="dt-lead">Most tools ask you to describe your data. This one <strong>uses it.</strong> Import a CSV or paste a table, pick what to produce, and the skill runs grounded in your actual rows — then export it, and translate the finished artifact into another language.</p>
+
+  <div class="card">
+    <label class="fld">1 · Your data</label>
+    <div class="row">
+      <input id="fileIn" type="file" accept=".csv,text/csv,text/plain" class="mini" />
+      <span class="mini">or paste below · or</span>
+      <input id="sheetUrl" type="text" placeholder="published Google Sheet CSV URL" style="flex:1;min-width:200px" />
+      <button id="fetchBtn" class="exp-btn" type="button">Fetch</button>
+    </div>
+    <textarea id="data" placeholder="Paste CSV or a table here — e.g.&#10;month,signups,revenue&#10;Jan,120,4300&#10;Feb,180,6600"></textarea>
+    <div id="preview" class="grid"></div>
+  </div>
+
+  <div class="card">
+    <label class="fld" for="skillSelect">2 · What to produce</label>
+    <div class="row">
+      <select id="skillSelect"><option value="">— free instruction —</option></select>
+    </div>
+    <label class="fld" for="instruction">Instruction (used as-is, or added to the skill)</label>
+    <textarea id="instruction" placeholder="e.g. 'Analyse this cohort data, call out the trend and the one number that worries you, and recommend next steps.'"></textarea>
+    <div class="actions">
+      <button id="runBtn" class="primary" type="button">Run on my data</button>
+      <button id="stopBtn" class="ghost" type="button" hidden>Stop</button>
+      <span id="status" class="status"></span>
+    </div>
+  </div>
+
+  <div class="card" id="outCard" hidden>
+    <div class="actions">
+      <button class="exp-btn" data-x="pdf" type="button">⬇ PDF</button>
+      <button class="exp-btn" data-x="docx" type="button">⬇ Word</button>
+      <button class="exp-btn" data-x="xlsx" type="button">⬇ Excel</button>
+      <span class="mini">🌐 Translate &amp; download:</span>
+      <select id="lang"></select>
+      <button id="translateBtn" class="exp-btn" type="button">Translate</button>
+    </div>
+    <article id="out" class="output markdown"></article>
+  </div>
+</div>
+
+<script>
+const el=(id)=>document.getElementById(id);
+let SKILLS=[], controller=null, LASTMD='';
+const LANGS=[['es','Spanish'],['fr','French'],['de','German'],['pt','Portuguese'],['hi','Hindi'],['ja','Japanese'],['zh','Chinese (Simplified)'],['ar','Arabic'],['it','Italian'],['ko','Korean']];
+
+init();
+async function init(){
+  PMProviders.initProviderUI();
+  el('keyToggle').addEventListener('click',()=>{const f=el('apiKey');const s=f.type==='password';f.type=s?'text':'password';el('keyToggle').textContent=s?'Hide':'Show';});
+  el('fileIn').addEventListener('change',onFile);
+  el('fetchBtn').addEventListener('click',fetchSheet);
+  el('data').addEventListener('input',preview);
+  el('runBtn').addEventListener('click',run);
+  el('stopBtn').addEventListener('click',()=>controller&&controller.abort());
+  el('translateBtn').addEventListener('click',translate);
+  document.querySelectorAll('#outCard [data-x]').forEach(b=>b.addEventListener('click',()=>doExport(b.dataset.x)));
+  for(const [c,n] of LANGS){ const o=document.createElement('option'); o.value=n; o.textContent=n; el('lang').appendChild(o); }
+  try{ SKILLS=(await (await fetch('skills.json')).json()).skills; SKILLS.sort((a,b)=>a.title.localeCompare(b.title)); for(const s of SKILLS){ const o=document.createElement('option'); o.value=s.name; o.textContent=s.title; el('skillSelect').appendChild(o);} }catch(e){}
+}
+function onFile(e){ const f=e.target.files[0]; if(!f) return; const r=new FileReader(); r.onload=()=>{ el('data').value=r.result; preview(); }; r.readAsText(f); }
+async function fetchSheet(){
+  const u=el('sheetUrl').value.trim(); if(!u) return;
+  setStatus('Fetching…');
+  try{ const t=await (await fetch(u)).text(); el('data').value=t; preview(); setStatus('Fetched.'); }
+  catch(e){ setStatus('Could not fetch (the sheet must be "published to web" as CSV and allow access). Paste or upload instead.',true); }
+}
+function parseCsv(text){
+  return text.trim().split(/\r?\n/).slice(0,200).map(line=>{
+    const out=[]; let cur='',q=false;
+    for(let i=0;i<line.length;i++){ const c=line[i]; if(q){ if(c==='"'){ if(line[i+1]==='"'){cur+='"';i++;} else q=false; } else cur+=c; } else { if(c==='"') q=true; else if(c===','){ out.push(cur); cur=''; } else cur+=c; } }
+    out.push(cur); return out;
+  });
+}
+function preview(){
+  const t=el('data').value.trim(); const p=el('preview'); if(!t){ p.innerHTML=''; return; }
+  const rows=parseCsv(t).slice(0,8); if(rows.length<2){ p.innerHTML='<span class="mini">Add a header row + at least one data row for a preview.</span>'; return; }
+  p.innerHTML='<table class="prev"><thead><tr>'+rows[0].map(h=>'<th>'+esc(h)+'</th>').join('')+'</tr></thead><tbody>'+rows.slice(1).map(r=>'<tr>'+r.map(c=>'<td>'+esc(c)+'</td>').join('')+'</tr>').join('')+'</tbody></table><span class="mini">'+(parseCsv(t).length-1)+' data rows loaded</span>';
+}
+function esc(s){ return String(s).replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c])); }
+function current(){ return SKILLS.find(s=>s.name===el('skillSelect').value); }
+async function run(){
+  const key=el('apiKey').value.trim(); if(!key) return setStatus('Enter your provider key first.',true);
+  const data=el('data').value.trim(); if(!data) return setStatus('Import or paste your data first.',true);
+  const instr=el('instruction').value.trim(); const s=current();
+  if(!s && !instr) return setStatus('Pick a skill or write an instruction.',true);
+  const system=(s? s.instructions+'\n\n' : 'You are a rigorous analyst. Follow the user instruction precisely.\n\n')
+    +'CRITICAL: Ground everything in the DATA the user provides below. Use its real values; cite specific numbers; do not invent rows or figures. If the data is insufficient for part of the task, say so.';
+  const userMessage=(instr?instr+'\n\n':'')+'DATA (CSV/table):\n"""\n'+data+'\n"""';
+  if(window.pmTrack) pmTrack('data/run');
+  el('outCard').hidden=false; const out=el('out'); out.innerHTML=''; out.dataset.raw='';
+  el('runBtn').disabled=true; el('stopBtn').hidden=false; controller=new AbortController(); setStatus('Analysing your data…');
+  try{
+    const acc=await PMProviders.stream({key,model:el('model').value,system,userMessage,signal:controller.signal,onDelta:(a)=>{out.innerHTML=DOMPurify.sanitize(marked.parse(a));}});
+    out.dataset.raw=acc; LASTMD=acc; setStatus('Done — export or translate below.');
+  }catch(e){ setStatus(e.name==='AbortError'?'Stopped.':(e.message||'Failed.'),true); }
+  finally{ el('runBtn').disabled=false; el('stopBtn').hidden=true; controller=null; }
+}
+function doExport(kind){
+  const md=el('out').dataset.raw||LASTMD; if(!md) return;
+  const title=(current()&&current().name)||'analysis';
+  if(kind==='pdf') return PMExport.pdf(md,title,{theme:'modern'});
+  if(kind==='docx') return PMExport.word(md,title);
+  if(kind==='xlsx') return PMExport.xlsx(md,title);
+}
+async function translate(){
+  const key=el('apiKey').value.trim(); if(!key) return setStatus('Enter your provider key first.',true);
+  const md=el('out').dataset.raw||LASTMD; if(!md) return setStatus('Run something first.',true);
+  const lang=el('lang').value;
+  if(window.pmTrack) pmTrack('data/translate');
+  el('translateBtn').disabled=true; setStatus('Translating to '+lang+'…'); controller=new AbortController();
+  try{
+    const system='You are a professional translator. Translate the user\'s markdown document into '+lang+', preserving all markdown structure (headings, tables, lists, bold). Translate content and table cells; keep numbers, code, and proper nouns intact. Output only the translated markdown.';
+    const acc=await PMProviders.stream({key,model:el('model').value,system,userMessage:md,signal:controller.signal});
+    const title=((current()&&current().name)||'analysis')+'-'+lang.toLowerCase().replace(/[^a-z]+/g,'-');
+    PMExport.word(acc,title);
+    setStatus('Translated → downloaded '+title+'.doc');
+  }catch(e){ setStatus(e.message||'Translation failed.',true); }
+  finally{ el('translateBtn').disabled=false; controller=null; }
+}
+function setStatus(m,err){ const s=el('status'); s.textContent=m; s.className='status'+(err?' err':''); }
+</script>
+<script src="i18n.js"></script>
+<script src="nav.js"></script>
+</body>
+</html>

--- a/web/meeting.html
+++ b/web/meeting.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Meeting → artifacts — a transcript becomes notes, an action tracker, and follow-up emails</title>
+<meta name="description" content="Paste a meeting transcript or rough notes and get three finished artifacts in one pass: clean minutes, an owner/due action tracker (export to Excel), and ready-to-send follow-up emails — then download the whole set as a zip. Runs in your browser." />
+<link rel="stylesheet" href="styles.css" />
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js" integrity="sha384-NNQgBjjuhtXzPmmy4gurS5X7P4uTt1DThyevz4Ua0IVK5+kazYQI1W27JHjbbxQz" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js" integrity="sha384-3HPB1XT51W3gGRxAmZ+qbZwRpRlFQL632y8x+adAqCr4Wp3TaWwCLSTAJJKbyWEK" crossorigin="anonymous"></script>
+<script src="providers.js"></script>
+<script src="export-doc.js"></script>
+<style>
+  .mt-wrap { max-width: 840px; margin: 0 auto; padding: 16px 22px 70px; }
+  .mt-lead { color: var(--muted); font-size: 15px; line-height: 1.55; }
+  textarea { width: 100%; box-sizing: border-box; min-height: 200px; padding: 12px 14px; background: var(--panel); border: 1px solid var(--border); border-radius: 12px; color: var(--text); font-family: inherit; font-size: 14px; line-height: 1.5; }
+  .actions { margin: 14px 0; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+  .seg { border: 1px solid var(--border); border-radius: 14px; margin: 14px 0; overflow: hidden; }
+  .seg > header { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 11px 15px; background: var(--panel-2); font-weight: 600; font-size: 14px; }
+  .seg .body { padding: 14px 16px; }
+  .exp-btn { background: var(--panel); border: 1px solid var(--border); color: var(--text); border-radius: 8px; padding: 6px 11px; cursor: pointer; font-size: 12.5px; }
+  .exp-btn:hover { border-color: var(--accent); }
+  .mini { font-size: 12px; color: var(--muted); }
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
+    <div class="brand-text"><h1>Meeting → artifacts</h1><p class="tagline">A transcript in. Minutes, an action tracker, and the follow-up emails out.</p></div>
+  </div>
+  <div class="key-area">
+    <select id="provider" title="Model provider"><option value="gemini">Gemini (free key)</option><option value="webllm">In-browser (no key)</option><option value="anthropic">Claude</option><option value="openai">OpenAI</option><option value="ollama">Ollama (local)</option></select>
+    <div class="key-field"><input id="apiKey" type="password" placeholder="sk-ant-… (your Anthropic API key)" autocomplete="off" /><button id="keyToggle" type="button" class="show-toggle">Show</button></div>
+    <select id="model" title="Model"><option value="claude-opus-4-8">Opus 4.8</option><option value="claude-sonnet-4-6" selected>Sonnet 4.6</option><option value="claude-haiku-4-5-20251001">Haiku 4.5</option></select>
+  </div>
+</header>
+<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+<div class="key-note">🔒 Your key + transcript stay in your browser and go only to your chosen provider — never to us.</div>
+
+<div class="mt-wrap">
+  <p class="mt-lead">Grounded in your real meeting — not a generic template. Paste the transcript (or messy notes) and get three finished artifacts in one pass, each exportable, plus a one-click zip of the set.</p>
+  <textarea id="transcript" placeholder="Paste the meeting transcript or your rough notes here…"></textarea>
+  <div class="actions">
+    <button id="runBtn" class="primary" type="button">Process the meeting</button>
+    <button id="stopBtn" class="ghost" type="button" hidden>Stop</button>
+    <button id="zipBtn" class="ghost" type="button" hidden>⬇ Download all (.zip)</button>
+    <span id="status" class="status"></span>
+  </div>
+
+  <div id="segments"></div>
+</div>
+
+<script>
+const el=(id)=>document.getElementById(id);
+let controller=null, PARTS={ notes:'', actions:'', emails:'' };
+const SEP={ notes:'===NOTES===', actions:'===ACTIONS===', emails:'===EMAILS===' };
+
+init();
+function init(){
+  PMProviders.initProviderUI();
+  el('keyToggle').addEventListener('click',()=>{const f=el('apiKey');const s=f.type==='password';f.type=s?'text':'password';el('keyToggle').textContent=s?'Hide':'Show';});
+  el('runBtn').addEventListener('click',run);
+  el('stopBtn').addEventListener('click',()=>controller&&controller.abort());
+  el('zipBtn').addEventListener('click',downloadZip);
+}
+function sysPrompt(){
+  return `You are an exacting chief-of-staff. From the meeting transcript/notes the user provides, produce THREE artifacts, each after its exact delimiter line and nothing before the first one:
+
+${SEP.notes}
+## Meeting notes
+Clean, skimmable minutes: a one-line summary, attendees if inferable, **Decisions** made, **Discussion** highlights (grouped by topic), and **Open questions**. Faithful to what was said — never invent outcomes.
+
+${SEP.actions}
+## Action items
+A single markdown table with columns exactly: | Action | Owner | Due | Priority |. One row per concrete commitment. Use "TBD" where unknown; infer dates only if clearly stated. If there are no actions, write a one-row table saying so.
+
+${SEP.emails}
+## Follow-up emails
+One short, ready-to-send email per person who owns actions (or a single recap email if owners are unclear). Each as: **To:** … / **Subject:** … then the body. Warm, specific, and brief.
+
+Output only those three delimited sections.`;
+}
+async function run(){
+  const key=el('apiKey').value.trim(); if(!key) return setStatus('Enter your provider key first.',true);
+  const tx=el('transcript').value.trim(); if(tx.length<40) return setStatus('Paste a real transcript or notes first.',true);
+  if(window.pmTrack) pmTrack('meeting/process');
+  el('runBtn').disabled=true; el('stopBtn').hidden=false; el('zipBtn').hidden=true; controller=new AbortController(); setStatus('Working…');
+  el('segments').innerHTML='';
+  try{
+    const acc=await PMProviders.stream({key,model:el('model').value,system:sysPrompt(),userMessage:tx,signal:controller.signal,onDelta:(a)=>{ render(split(a)); }});
+    PARTS=split(acc); render(PARTS); el('zipBtn').hidden=!(PARTS.notes||PARTS.actions||PARTS.emails); setStatus('Done — export below.');
+  }catch(e){ setStatus(e.name==='AbortError'?'Stopped.':(e.message||'Failed.'),true); }
+  finally{ el('runBtn').disabled=false; el('stopBtn').hidden=true; controller=null; }
+}
+function split(text){
+  const grab=(a,b)=>{ const i=text.indexOf(a); if(i<0) return ''; const s=i+a.length; const j=b?text.indexOf(b,s):-1; return text.slice(s, j<0?undefined:j).trim(); };
+  return { notes:grab(SEP.notes,SEP.actions), actions:grab(SEP.actions,SEP.emails), emails:grab(SEP.emails,null) };
+}
+const SEGS=[
+  ['notes','📝 Meeting notes',['docx','pdf']],
+  ['actions','✅ Action tracker',['xlsx','docx']],
+  ['emails','✉️ Follow-up emails',['docx']],
+];
+function render(parts){
+  el('segments').innerHTML=SEGS.filter(([k])=>parts[k]).map(([k,label,fmts])=>{
+    const btns=fmts.map(f=>`<button class="exp-btn" data-k="${k}" data-f="${f}">⬇ ${f==='xlsx'?'Excel':f==='pdf'?'PDF':'Word'}</button>`).join(' ');
+    return `<div class="seg"><header><span>${label}</span><span>${btns}</span></header><div class="body markdown" id="seg-${k}">${DOMPurify.sanitize(marked.parse(parts[k]))}</div></div>`;
+  }).join('');
+  document.querySelectorAll('#segments .exp-btn').forEach(b=>b.addEventListener('click',()=>expOne(b.dataset.k,b.dataset.f)));
+}
+function titleFor(k){ return k==='notes'?'meeting-notes':k==='actions'?'action-items':'follow-up-emails'; }
+function expOne(k,f){
+  const md=PARTS[k]; if(!md) return;
+  if(f==='xlsx') return PMExport.xlsx(md,titleFor(k));
+  if(f==='pdf') return PMExport.pdf(md,titleFor(k),{theme:'modern'});
+  return PMExport.word(md,titleFor(k));
+}
+// A lib-free .doc (Office-HTML) blob, so the zip needs only JSZip.
+function docBlob(md){ const html="<html xmlns:o='urn:schemas-microsoft-com:office:office' xmlns:w='urn:schemas-microsoft-com:office:word' xmlns='http://www.w3.org/TR/REC-html40'><head><meta charset='utf-8'><style>body{font-family:Calibri,Arial,sans-serif;font-size:11pt;line-height:1.5}table{border-collapse:collapse}td,th{border:1px solid #999;padding:4pt 8pt}</style></head><body>"+DOMPurify.sanitize(marked.parse(md||''))+"</body></html>"; return new Blob(['﻿',html],{type:'application/msword'}); }
+function csvFromActions(md){
+  const rows=(md||'').split('\n').filter(l=>/^\s*\|.*\|\s*$/.test(l) && !/^\s*\|?[\s:|-]+\|?\s*$/.test(l));
+  return rows.map(l=>l.trim().replace(/^\||\|$/g,'').split('|').map(c=>{const v=c.trim().replace(/\*\*/g,'').replace(/"/g,'""');return /[",\n]/.test(v)?'"'+v+'"':v;}).join(',')).join('\n');
+}
+async function downloadZip(){
+  setStatus('Zipping…');
+  try{
+    await new Promise((res,rej)=>{ if(window.JSZip) return res(); const s=document.createElement('script'); s.src='https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js'; s.integrity='sha384-+mbV2IY1Zk/X1p/nWllGySJSUN8uMs+gUAN10Or95UBH0fpj6GfKgPmgC5EXieXG'; s.crossOrigin='anonymous'; s.onload=res; s.onerror=()=>rej(new Error('Could not load zip library')); document.head.appendChild(s); });
+    const zip=new JSZip();
+    if(PARTS.notes) zip.file('meeting-notes.doc', docBlob(PARTS.notes));
+    if(PARTS.actions){ zip.file('action-items.doc', docBlob(PARTS.actions)); const csv=csvFromActions(PARTS.actions); if(csv) zip.file('action-items.csv', csv); }
+    if(PARTS.emails) zip.file('follow-up-emails.doc', docBlob(PARTS.emails));
+    const blob=await zip.generateAsync({type:'blob'});
+    const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='meeting-packet.zip'; document.body.appendChild(a); a.click(); setTimeout(()=>{URL.revokeObjectURL(a.href);a.remove();},1000);
+    setStatus('Downloaded meeting-packet.zip.');
+  }catch(e){ setStatus(e.message||'Zip failed.',true); }
+}
+function setStatus(m,err){ const s=el('status'); s.textContent=m; s.className='status'+(err?' err':''); }
+</script>
+<script src="i18n.js"></script>
+<script src="nav.js"></script>
+</body>
+</html>

--- a/web/nav.js
+++ b/web/nav.js
@@ -58,6 +58,9 @@
     { href: 'galaxy3d.html', label: '🌌 Galaxy 3D' },
     { group: '🆕 New', items: [
       ['make.html', '🏭 Make it real'],
+      ['meeting.html', '🗒️ Meeting → artifacts'],
+      ['data.html', '📊 Bring your own data'],
+      ['site.html', '🌐 Site builder'],
       ['teardown.html', '🔨 Teardown Engine'],
       ['deck.html', '🃏 Operator\'s Deck'],
       ['firm-game.html', '🎮 Run the Firm (game)'],

--- a/web/site.html
+++ b/web/site.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Site &amp; interactive builder — turn a skill into a downloadable website or a living document</title>
+<meta name="description" content="Describe what you need and get a complete, self-contained web page you can host anywhere — a portfolio, a landing page, a one-pager microsite — or a living document (an editable checklist or weighted scorecard) that stays interactive after you download it. No build step, no backend." />
+<link rel="stylesheet" href="styles.css" />
+<script src="providers.js"></script>
+<style>
+  .st-wrap { max-width: 900px; margin: 0 auto; padding: 16px 22px 70px; }
+  .st-lead { color: var(--muted); font-size: 15px; line-height: 1.55; }
+  .types { display: flex; gap: 8px; flex-wrap: wrap; margin: 12px 0; }
+  .type { border: 1px solid var(--border); border-radius: 12px; padding: 9px 13px; cursor: pointer; font-size: 13.5px; background: var(--panel); }
+  .type.sel { border-color: var(--accent); background: rgba(217,96,90,.07); }
+  textarea { width: 100%; box-sizing: border-box; min-height: 110px; padding: 12px 14px; background: var(--panel); border: 1px solid var(--border); border-radius: 12px; color: var(--text); font-family: inherit; font-size: 14px; line-height: 1.5; }
+  .actions { margin: 12px 0; display: flex; gap: 8px; flex-wrap: wrap; align-items: center; }
+  .frame { width: 100%; height: 560px; border: 1px solid var(--border); border-radius: 12px; background: #fff; margin-top: 12px; }
+  .mini { font-size: 12px; color: var(--muted); }
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
+    <div class="brand-text"><h1>Site &amp; interactive builder</h1><p class="tagline">A skill → a downloadable website, or a document that stays alive.</p></div>
+  </div>
+  <div class="key-area">
+    <select id="provider" title="Model provider"><option value="gemini">Gemini (free key)</option><option value="webllm">In-browser (no key)</option><option value="anthropic">Claude</option><option value="openai">OpenAI</option><option value="ollama">Ollama (local)</option></select>
+    <div class="key-field"><input id="apiKey" type="password" placeholder="sk-ant-… (your Anthropic API key)" autocomplete="off" /><button id="keyToggle" type="button" class="show-toggle">Show</button></div>
+    <select id="model" title="Model"><option value="claude-opus-4-8">Opus 4.8</option><option value="claude-sonnet-4-6" selected>Sonnet 4.6</option><option value="claude-haiku-4-5-20251001">Haiku 4.5</option></select>
+  </div>
+</header>
+<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+<div class="key-note">🔒 Your key + brief stay in your browser. The generated page is self-contained HTML you can host anywhere. Preview runs sandboxed.</div>
+
+<div class="st-wrap">
+  <p class="st-lead">Skills don't have to stop at a document. Describe what you want and get a <strong>complete, single-file web page</strong> — everything inlined, no build step — that you can open, host, or send. Pick an <em>interactive</em> type and the download keeps working: tick the checklist, drag the weights, and it remembers.</p>
+
+  <div class="types" id="types"></div>
+  <textarea id="brief" placeholder="Describe it — e.g. 'A one-page portfolio for a product designer named Ravi: hero, 4 case studies, skills, contact. Calm, modern, dark theme.'"></textarea>
+  <div class="actions">
+    <button id="runBtn" class="primary" type="button">Build it</button>
+    <button id="stopBtn" class="ghost" type="button" hidden>Stop</button>
+    <button id="dlBtn" class="ghost" type="button" hidden>⬇ Download .html</button>
+    <button id="openBtn" class="ghost" type="button" hidden>↗ Open in new tab</button>
+    <span id="status" class="status"></span>
+  </div>
+  <iframe id="frame" class="frame" sandbox="allow-scripts allow-forms" title="preview" hidden></iframe>
+</div>
+
+<script>
+const el=(id)=>document.getElementById(id);
+let controller=null, LASTHTML='';
+const TYPES=[
+  ['portfolio','🧑‍🎨 Portfolio','a personal portfolio site'],
+  ['landing','🚀 Landing page','a product landing page with a hero, features, and a call to action'],
+  ['onepager','📄 One-pager microsite','a single-scroll microsite that summarises a document or pitch'],
+  ['checklist','✅ Interactive checklist','a living checklist where each item is a real checkbox that saves its state to localStorage, with a progress bar'],
+  ['scorecard','🎚️ Interactive scorecard','a weighted scorecard where each criterion has an adjustable weight and score, and the total recomputes live'],
+];
+let sel='portfolio';
+init();
+function init(){
+  PMProviders.initProviderUI();
+  el('keyToggle').addEventListener('click',()=>{const f=el('apiKey');const s=f.type==='password';f.type=s?'text':'password';el('keyToggle').textContent=s?'Hide':'Show';});
+  el('types').innerHTML=TYPES.map(t=>`<span class="type${t[0]===sel?' sel':''}" data-id="${t[0]}">${t[1]}</span>`).join('');
+  document.querySelectorAll('.type').forEach(d=>d.addEventListener('click',()=>{ sel=d.dataset.id; document.querySelectorAll('.type').forEach(x=>x.classList.toggle('sel',x.dataset.id===sel)); }));
+  el('runBtn').addEventListener('click',run);
+  el('stopBtn').addEventListener('click',()=>controller&&controller.abort());
+  el('dlBtn').addEventListener('click',download);
+  el('openBtn').addEventListener('click',openTab);
+}
+function sysPrompt(){
+  const t=TYPES.find(x=>x[0]===sel);
+  const interactive=(sel==='checklist'||sel==='scorecard');
+  return `You are an expert front-end engineer and designer. Produce ${t[2]} as ONE complete, self-contained HTML document.
+
+Hard rules:
+- Output ONLY the HTML, starting with <!DOCTYPE html>. No markdown, no code fences, no commentary.
+- Everything inline: all CSS in a style block, all JS in one script block. NO external resources of any kind (no CDN links, no web fonts, no images by URL) — use system fonts, CSS, and inline SVG only, so the file works offline anywhere.
+- Responsive, accessible, and polished. Support light and dark via prefers-color-scheme.
+${interactive ? '- It MUST be genuinely interactive with vanilla JS: '+(sel==='checklist'?'real checkboxes that persist to localStorage and a live progress bar/percentage.':'number/range inputs for each weight and score, with a total that recomputes live and persists to localStorage.') : '- Fill it with sensible, specific placeholder content derived from the brief.'}
+- No tracking, no forms that post anywhere.`;
+}
+async function run(){
+  const key=el('apiKey').value.trim(); if(!key) return setStatus('Enter your provider key first.',true);
+  const brief=el('brief').value.trim(); if(!brief) return setStatus('Describe what to build first.',true);
+  if(window.pmTrack) pmTrack('site/'+sel);
+  el('runBtn').disabled=true; el('stopBtn').hidden=false; el('dlBtn').hidden=true; el('openBtn').hidden=true; controller=new AbortController(); setStatus('Building…');
+  el('frame').hidden=false;
+  try{
+    let acc='';
+    acc=await PMProviders.stream({key,model:el('model').value,system:sysPrompt(),userMessage:brief,signal:controller.signal,onDelta:(a)=>{ el('frame').srcdoc=stripFence(a); }});
+    LASTHTML=stripFence(acc); el('frame').srcdoc=LASTHTML;
+    el('dlBtn').hidden=false; el('openBtn').hidden=false; setStatus('Done — preview above. Download or open it.');
+  }catch(e){ setStatus(e.name==='AbortError'?'Stopped.':(e.message||'Failed.'),true); }
+  finally{ el('runBtn').disabled=false; el('stopBtn').hidden=true; controller=null; }
+}
+function stripFence(s){ return (s||'').replace(/^\s*```(?:html)?\s*/i,'').replace(/```\s*$/,'').trim(); }
+function download(){ if(!LASTHTML) return; const blob=new Blob([LASTHTML],{type:'text/html'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download=sel+'-site.html'; document.body.appendChild(a); a.click(); setTimeout(()=>{URL.revokeObjectURL(a.href);a.remove();},1000); }
+function openTab(){ if(!LASTHTML) return; const blob=new Blob([LASTHTML],{type:'text/html'}); const u=URL.createObjectURL(blob); window.open(u,'_blank','noopener'); setTimeout(()=>URL.revokeObjectURL(u),4000); }
+function setStatus(m,err){ const s=el('status'); s.textContent=m; s.className='status'+(err?' err':''); }
+</script>
+<script src="i18n.js"></script>
+<script src="nav.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Second of two PRs on the **"skills produce real artifacts"** theme (PR A is #151). Five features that take skills *past* a single static document — three self-contained pages, all client-side on the shared `PMProviders` + `PMExport` layer.

### The five features
- **⑥ Bring your own data** (`web/data.html`) — import a **CSV**, paste a table, or fetch a **published Google Sheet**, and run any skill **grounded in the real rows** (cite the numbers; no invented figures). Live preview of the parsed table, then export Word/PDF/Excel.
- **⑨ Multilingual export** (in `data.html`) — translate the finished artifact into any of **10 languages** (markdown structure preserved) and download it, one click.
- **⑩ Meeting → artifacts** (`web/meeting.html`) — paste a transcript and get **three finished artifacts in one pass**: clean minutes, an Owner/Due/Priority **action tracker** (→ Excel), and ready-to-send **follow-up emails** — plus a one-click **`.zip`** of the whole set (lib-free `.doc` + `.csv` via JSZip).
- **⑦ Site generator** (`web/site.html`) — describe it and get **one complete, self-contained HTML page** (everything inlined, works offline): portfolio, landing page, or one-pager microsite. Sandboxed live preview, download, open-in-tab.
- **⑧ Interactive-doc export** (in `site.html`) — the **checklist** and **weighted scorecard** types generate vanilla-JS documents that **stay alive after download**: tick items, drag weights, state persists to `localStorage`.

### Safety / notes
- The generated site preview renders in a **sandboxed iframe** (`allow-scripts allow-forms` only); the model is instructed to inline everything and use no external resources.
- No new npm deps; JSZip loads lazily with the **SRI hash computed from the real file**. Reuses the existing SRI-pinned CDN pattern.
- Three "🆕 New" nav entries (Meeting → artifacts, Bring your own data, Site builder).

### Verification
Headless Chromium over a local HTTP server: all three pages load with their key controls present and **zero console errors**. Model-dependent generation (analysis, translation, site HTML) runs at use time via the user's provider key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_