### PR TITLE
feat: sensory & living visuals — Voice, Live Capture, Video, War Table, Holo Cards (PR 1 of 2)

### DIFF
--- a/web/capture.html
+++ b/web/capture.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Live Capture — point your camera, get the artifact</title>
+<meta name="description" content="Point your phone or webcam at a whiteboard, a contract, a shelf of files, or a screen — and turn what it sees into a structured artifact live, with a scanning overlay. Vision-powered, runs in your browser." />
+<link rel="stylesheet" href="styles.css" />
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js" integrity="sha384-NNQgBjjuhtXzPmmy4gurS5X7P4uTt1DThyevz4Ua0IVK5+kazYQI1W27JHjbbxQz" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js" integrity="sha384-3HPB1XT51W3gGRxAmZ+qbZwRpRlFQL632y8x+adAqCr4Wp3TaWwCLSTAJJKbyWEK" crossorigin="anonymous"></script>
+<script src="providers.js"></script>
+<style>
+  .c-wrap { max-width: 820px; margin: 0 auto; padding: 12px 22px 60px; }
+  .stage { position: relative; border-radius: 16px; overflow: hidden; background: #000; aspect-ratio: 4/3; max-height: 60vh; margin: 0 auto; }
+  #video { width: 100%; height: 100%; object-fit: cover; display: block; }
+  #scan { position: absolute; inset: 0; pointer-events: none; }
+  .pick { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin: 12px 0; }
+  .pick select { padding: 9px 12px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 14px; }
+  .actions { display: flex; gap: 8px; flex-wrap: wrap; align-items: center; margin: 6px 0; }
+  .out { border: 1px solid var(--border); border-radius: 14px; padding: 14px 16px; margin-top: 14px; }
+  .warn { font-size: 12.5px; color: var(--muted); }
+  .exp-btn { background: var(--panel-2); border: 1px solid var(--border); color: var(--text); border-radius: 8px; padding: 7px 11px; cursor: pointer; font-size: 12.5px; }
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
+    <div class="brand-text"><h1>Live Capture</h1><p class="tagline">Point the camera. Get the artifact.</p></div>
+  </div>
+  <div class="key-area">
+    <select id="provider" title="Model provider"><option value="gemini">Gemini (free key)</option><option value="anthropic">Claude</option><option value="openai">OpenAI</option></select>
+    <div class="key-field"><input id="apiKey" type="password" placeholder="sk-ant-… (a vision-capable key)" autocomplete="off" /><button id="keyToggle" type="button" class="show-toggle">Show</button></div>
+    <select id="model" title="Model"><option value="claude-opus-4-8">Opus 4.8</option><option value="claude-sonnet-4-6" selected>Sonnet 4.6</option><option value="claude-haiku-4-5-20251001">Haiku 4.5</option></select>
+  </div>
+</header>
+<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+<div class="key-note">🔒 The camera frame goes only to your chosen vision provider (Claude, Gemini, or OpenAI) — never to us. Only capture things you're allowed to.</div>
+
+<div class="c-wrap">
+  <div class="pick">
+    <button id="startCam" class="primary" type="button">📷 Start camera</button>
+    <button id="flipCam" class="ghost" type="button" hidden>🔄 Flip</button>
+    <span class="warn">then turn it into a</span>
+    <select id="mode">
+      <option value="auto">— auto: read what you see —</option>
+      <option value="whiteboard-to-spec">📝 Spec (from a whiteboard)</option>
+      <option value="screenshot-teardown">🔍 Teardown (from a screen)</option>
+      <option value="deck-autopsy">🎯 Slide critique</option>
+      <option value="table">📊 Data table (from a chart/sheet)</option>
+      <option value="contract">⚖️ Contract summary + red flags</option>
+      <option value="todo">✅ Action list (from notes)</option>
+    </select>
+  </div>
+
+  <div class="stage" id="stage" hidden>
+    <video id="video" playsinline muted></video>
+    <canvas id="scan"></canvas>
+  </div>
+
+  <div class="actions" style="margin-top:12px">
+    <button id="shoot" class="primary" type="button" hidden>✨ Capture &amp; read</button>
+    <button id="stopBtn" class="ghost" type="button" hidden>Stop</button>
+    <span id="status" class="status"></span>
+  </div>
+  <p class="warn" id="err" hidden></p>
+
+  <div class="out" id="outCard" hidden>
+    <div class="actions">
+      <strong style="flex:1">Result</strong>
+      <button class="exp-btn" data-x="docx" type="button">⬇ Word</button>
+      <button class="exp-btn" data-x="pdf" type="button">⬇ PDF</button>
+      <button class="exp-btn" data-x="copy" type="button">Copy</button>
+    </div>
+    <article id="out" class="output markdown"></article>
+  </div>
+</div>
+
+<script src="export-doc.js"></script>
+<script>
+const el=(id)=>document.getElementById(id);
+let stream=null, facing='environment', controller=null, scanRAF=null, scanning=false, LASTMD='';
+const PROMPTS={
+  'auto':'Look at this image and produce the single most useful structured artifact from it — infer what it is (a whiteboard, a document, a screen, a chart, a shelf) and turn it into the appropriate professional output. Start by naming what you saw in one line.',
+  'whiteboard-to-spec':'This is a photo of a whiteboard or sketch. Turn it into a clean, structured spec: goal, requirements, open questions. Transcribe boxes/arrows faithfully; never invent.',
+  'screenshot-teardown':'This is a screenshot of a product UI or page. Give a sharp teardown: what works, the top usability/clarity problems (quote on-screen text), and the highest-leverage fixes.',
+  'deck-autopsy':'This is a photo of a slide. Critique it like a senior reviewer: the one message, what fights it, and a tighter rewrite of the headline + bullets.',
+  'table':'This image contains a chart or spreadsheet. Extract the data into a clean markdown table (exact values where legible; mark unclear cells). Add a one-line read of the trend.',
+  'contract':'This is a photo of a contract/agreement page. Summarise it in plain English and list the clauses that could hurt the signer, ranked, with the questions to ask. Note this is not legal advice.',
+  'todo':'This is a photo of handwritten or typed notes. Extract a clean, prioritised action list with owners/dates where stated (TBD otherwise).',
+};
+init();
+function init(){
+  PMProviders.initProviderUI();
+  el('keyToggle').addEventListener('click',()=>{const f=el('apiKey');const s=f.type==='password';f.type=s?'text':'password';el('keyToggle').textContent=s?'Hide':'Show';});
+  el('startCam').addEventListener('click',start);
+  el('flipCam').addEventListener('click',flip);
+  el('shoot').addEventListener('click',shoot);
+  el('stopBtn').addEventListener('click',()=>controller&&controller.abort());
+  document.querySelectorAll('#outCard [data-x]').forEach(b=>b.addEventListener('click',()=>doExport(b.dataset.x)));
+  window.addEventListener('resize',fitScan);
+}
+async function start(){
+  try{
+    stream&&stream.getTracks().forEach(t=>t.stop());
+    stream=await navigator.mediaDevices.getUserMedia({ video:{ facingMode:facing }, audio:false });
+    el('video').srcObject=stream; await el('video').play();
+    el('stage').hidden=false; el('shoot').hidden=false; el('flipCam').hidden=false; el('startCam').textContent='📷 Restart';
+    fitScan();
+  }catch(e){ el('err').hidden=false; el('err').textContent='Camera unavailable: '+(e.message||e)+'. On desktop, allow camera access; on iPhone use Safari.'; }
+}
+function flip(){ facing=facing==='environment'?'user':'environment'; start(); }
+function fitScan(){ const v=el('video'),s=el('scan'); s.width=v.clientWidth; s.height=v.clientHeight; }
+function animateScan(){
+  const s=el('scan'), x=s.getContext('2d'), W=s.width, H=s.height; scanning=true; let t0=performance.now();
+  (function loop(t){ if(!scanning){ x.clearRect(0,0,W,H); return; }
+    const p=((t-t0)%1600)/1600; x.clearRect(0,0,W,H);
+    x.strokeStyle='rgba(120,200,255,0.9)'; x.lineWidth=2; const y=p*H;
+    x.beginPath(); x.moveTo(0,y); x.lineTo(W,y); x.stroke();
+    const g=x.createLinearGradient(0,y-40,0,y); g.addColorStop(0,'rgba(120,200,255,0)'); g.addColorStop(1,'rgba(120,200,255,0.25)'); x.fillStyle=g; x.fillRect(0,y-40,W,40);
+    // corner brackets
+    x.strokeStyle='rgba(120,200,255,0.8)'; const m=18,L=30;
+    [[m,m,1,1],[W-m,m,-1,1],[m,H-m,1,-1],[W-m,H-m,-1,-1]].forEach(([cx,cy,dx,dy])=>{ x.beginPath(); x.moveTo(cx,cy+dy*L); x.lineTo(cx,cy); x.lineTo(cx+dx*L,cy); x.stroke(); });
+    scanRAF=requestAnimationFrame(loop);
+  })(t0);
+}
+function stopScan(){ scanning=false; if(scanRAF)cancelAnimationFrame(scanRAF); const s=el('scan'); s.getContext('2d').clearRect(0,0,s.width,s.height); }
+function grabFrame(){ const v=el('video'), c=document.createElement('canvas'); const w=Math.min(1280,v.videoWidth||1280); const scale=w/(v.videoWidth||w); c.width=w; c.height=(v.videoHeight||960)*scale; c.getContext('2d').drawImage(v,0,0,c.width,c.height); return c.toDataURL('image/jpeg',0.72).split(',')[1]; }
+async function shoot(){
+  const key=el('apiKey').value.trim(); if(!key) return setStatus('Enter a vision-capable provider key.',true);
+  if(!stream) return setStatus('Start the camera first.',true);
+  const data=grabFrame();
+  const mode=el('mode').value;
+  const system='You are an expert who turns a photographed real-world artifact into a clean, structured professional deliverable in markdown. Be faithful to what is actually visible; if something is illegible, say so rather than guessing.';
+  const userMessage=PROMPTS[mode]||PROMPTS.auto;
+  if(window.pmTrack) pmTrack('capture/'+mode);
+  animateScan(); el('outCard').hidden=false; const out=el('out'); out.innerHTML=''; out.dataset.raw='';
+  el('shoot').disabled=true; el('stopBtn').hidden=false; controller=new AbortController(); setStatus('Reading the frame…');
+  try{
+    const acc=await PMProviders.stream({key,model:el('model').value,system,userMessage,images:[{media_type:'image/jpeg',data}],signal:controller.signal,onDelta:(a)=>{ out.innerHTML=DOMPurify.sanitize(marked.parse(a)); }});
+    out.dataset.raw=acc; LASTMD=acc; setStatus('Done.');
+  }catch(e){ setStatus(e.name==='AbortError'?'Stopped.':(e.message||'Failed — does this provider/model support images?'),true); }
+  finally{ stopScan(); el('shoot').disabled=false; el('stopBtn').hidden=true; controller=null; }
+}
+function doExport(kind){ const md=LASTMD; if(!md) return; if(kind==='docx')return PMExport.word(md,'capture'); if(kind==='pdf')return PMExport.pdf(md,'capture',{theme:'modern'}); if(kind==='copy')navigator.clipboard.writeText(md); }
+function setStatus(m,err){ const s=el('status'); s.textContent=m; s.className='status'+(err?' err':''); }
+</script>
+<script src="i18n.js"></script>
+<script src="nav.js"></script>
+</body>
+</html>

--- a/web/holo.html
+++ b/web/holo.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Holo Cards — open a pack of skills</title>
+<meta name="description" content="Tear open a booster pack and pull holographic, tilt-reactive cards from the library of 515 skills — foil shimmer, parallax depth, rarities. A delightful, shareable way to discover what's inside." />
+<link rel="stylesheet" href="styles.css" />
+<style>
+  .h-wrap { max-width: 1000px; margin: 0 auto; padding: 14px 22px 60px; text-align: center; }
+  .h-lead { color: var(--muted); font-size: 15px; }
+  .pack { width: 220px; height: 320px; margin: 18px auto; border-radius: 18px; cursor: pointer; position: relative; overflow: hidden;
+    background: linear-gradient(150deg,#241a30,#3a2350 40%,#101318); border: 1px solid #4a3a6a; box-shadow: 0 20px 50px rgba(0,0,0,.5); transition: transform .3s; }
+  .pack:hover { transform: translateY(-6px) scale(1.02); }
+  .pack::after { content:''; position:absolute; inset:0; background: conic-gradient(from 0deg, transparent, rgba(255,255,255,.25), transparent 30%); animation: spin 5s linear infinite; mix-blend-mode: color-dodge; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .pack .plabel { position:absolute; inset:0; display:flex; flex-direction:column; align-items:center; justify-content:center; z-index:2; color:#f4e6bf; text-shadow:0 2px 8px #000; }
+  .pack .plabel b { font-size: 22px; letter-spacing: 2px; } .pack .plabel span { font-size: 12px; opacity:.8; margin-top:6px; }
+  .cards { display: flex; flex-wrap: wrap; gap: 18px; justify-content: center; margin: 20px 0; perspective: 1200px; }
+  .card { width: 210px; height: 300px; border-radius: 16px; position: relative; transform-style: preserve-3d; transition: transform .12s ease-out; cursor: pointer;
+    background: linear-gradient(160deg, var(--c1), var(--c2)); border: 1px solid rgba(255,255,255,.18); box-shadow: 0 16px 40px rgba(0,0,0,.45); overflow: hidden; animation: deal .5s ease backwards; }
+  @keyframes deal { from { opacity:0; transform: translateY(30px) rotateY(40deg); } }
+  .card .foil { position:absolute; inset:0; background: linear-gradient(115deg, transparent 20%, rgba(255,255,255,.55) 45%, rgba(120,220,255,.4) 50%, rgba(255,180,255,.4) 55%, transparent 80%);
+    background-size: 300% 300%; mix-blend-mode: color-dodge; opacity:.55; pointer-events:none; }
+  .card.holo .foil { background: conic-gradient(from var(--a,0deg), #ff8ad8, #8affd8, #8ab8ff, #ffd98a, #ff8ad8); opacity:.4; }
+  .card .inner { position: relative; z-index:2; height:100%; padding: 16px 15px; display:flex; flex-direction:column; color:#fff; text-shadow:0 1px 3px rgba(0,0,0,.4); }
+  .card .rar { font-size: 10px; letter-spacing: 2px; text-transform: uppercase; opacity:.9; }
+  .card .mono { font-size: 46px; font-weight:800; margin: 10px 0 4px; }
+  .card .nm { font-size: 17px; font-weight: 700; line-height: 1.2; }
+  .card .bd { font-size: 12px; opacity:.85; margin-top: auto; }
+  .card .desc { font-size: 11.5px; opacity:.9; margin-top: 8px; max-height: 92px; overflow:hidden; }
+  .card .cta { margin-top: 10px; display:flex; gap:6px; }
+  .card .cta a { font-size: 11px; background: rgba(0,0,0,.28); border:1px solid rgba(255,255,255,.3); color:#fff; border-radius: 6px; padding: 4px 8px; text-decoration:none; }
+  .actions { margin: 10px 0; display:flex; gap:8px; justify-content:center; flex-wrap:wrap; }
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
+    <div class="brand-text"><h1>Holo Cards</h1><p class="tagline">Open a pack. Pull a skill.</p></div>
+  </div>
+</header>
+<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+
+<div class="h-wrap">
+  <p class="h-lead">515 skills, dealt as holographic cards. Tap the pack, tilt the cards, pull a rare. Every card links straight into the Playground.</p>
+
+  <div id="packView">
+    <div class="pack" id="pack"><div class="plabel"><b>PM SKILLS</b><span>BOOSTER PACK · tap to open</span></div></div>
+  </div>
+
+  <div class="actions" id="postOpen" hidden>
+    <button id="again" class="primary" type="button">🎴 Open another pack</button>
+    <a class="btn" href="deck.html">🃏 The full deck</a>
+    <a class="btn" href="catalog.html">📚 Browse all</a>
+  </div>
+  <div class="cards" id="cards"></div>
+</div>
+
+<script>
+const el=(id)=>document.getElementById(id);
+let SKILLS=[];
+const PALETTES=[['#3a2350','#101318'],['#12384a','#0a1a24'],['#3a1230','#1a0a14'],['#123a2a','#0a1a14'],['#2a2a55','#101020'],['#4a3212','#1a1206']];
+init();
+async function init(){
+  el('pack').addEventListener('click',open);
+  el('again').addEventListener('click',open);
+  try{ SKILLS=(await (await fetch('skills.json')).json()).skills; }catch(e){}
+  const want=new URLSearchParams(location.search).get('skill');
+  if(want){ const s=SKILLS.find(k=>k.name===want); if(s){ el('packView').hidden=true; renderCards([s]); el('postOpen').hidden=false; } }
+}
+function rarity(s){ const sc=s.eval&&s.eval.score; if(sc>=4.6) return {r:'★ Holo Rare',holo:true}; if(sc>=4.2||/Production/i.test(s.tier||'')) return {r:'Rare',holo:true}; if(sc) return {r:'Uncommon',holo:false}; return {r:'Common',holo:false}; }
+function mono(s){ return (s.title||s.name).replace(/[^A-Za-z]/g,'').slice(0,2).toUpperCase()||'PM'; }
+function pick(n){ const out=[],used=new Set(); const pool=SKILLS.length?SKILLS:[]; let guard=0; while(out.length<n&&guard++<400){ const s=pool[Math.floor(Math.random()*pool.length)]; if(s&&!used.has(s.name)){ used.add(s.name); out.push(s); } } return out; }
+function open(){
+  el('packView').hidden=false; el('pack').style.transform='scale(1.15)'; el('pack').style.opacity='0.2';
+  setTimeout(()=>{ el('packView').hidden=true; el('pack').style.transform=''; el('pack').style.opacity=''; renderCards(pick(5)); el('postOpen').hidden=false; if(window.pmTrack)pmTrack('holo/open'); }, 320);
+}
+function renderCards(list){
+  el('cards').innerHTML=list.map((s,i)=>{
+    const rr=rarity(s); const pal=PALETTES[Math.abs(hash(s.name))%PALETTES.length];
+    const desc=(s.summary||s.description||'').slice(0,150);
+    return `<div class="card${rr.holo?' holo':''}" data-name="${s.name}" style="--c1:${pal[0]};--c2:${pal[1]};animation-delay:${i*0.08}s">
+      <div class="foil"></div>
+      <div class="inner">
+        <div class="rar">${rr.r}</div>
+        <div class="mono">${mono(s)}</div>
+        <div class="nm">${escape(s.title||s.name)}</div>
+        <div class="desc">${escape(desc)}</div>
+        <div class="bd">${escape(s.plugin||'pm-skills')}</div>
+        <div class="cta"><a href="index.html?skill=${encodeURIComponent(s.name)}">▶ Run</a><a href="holo.html?skill=${encodeURIComponent(s.name)}" onclick="event.stopPropagation()">🔗 Share</a></div>
+      </div></div>`;
+  }).join('');
+  document.querySelectorAll('.card').forEach(bindTilt);
+}
+function bindTilt(card){
+  function move(e){ const r=card.getBoundingClientRect(); const px=(e.clientX-r.left)/r.width, py=(e.clientY-r.top)/r.height;
+    const rx=(0.5-py)*18, ry=(px-0.5)*18; card.style.transform=`rotateX(${rx}deg) rotateY(${ry}deg) scale(1.04)`;
+    const f=card.querySelector('.foil'); f.style.backgroundPosition=(px*100)+'% '+(py*100)+'%'; card.style.setProperty('--a',(px*360)+'deg'); }
+  function reset(){ card.style.transform=''; }
+  card.addEventListener('mousemove',move); card.addEventListener('mouseleave',reset);
+  card.addEventListener('touchmove',(e)=>{ const t=e.touches[0]; move(t); },{passive:true}); card.addEventListener('touchend',reset);
+  window.addEventListener('deviceorientation',(e)=>{ if(e.gamma==null)return; const ry=Math.max(-14,Math.min(14,e.gamma)); const rx=Math.max(-14,Math.min(14,(e.beta-45))); card.style.transform=`rotateX(${-rx}deg) rotateY(${ry}deg)`; card.querySelector('.foil').style.backgroundPosition=(50+ry*3)+'% '+(50+rx*3)+'%'; });
+}
+function hash(s){ let h=0; for(let i=0;i<s.length;i++)h=(h*31+s.charCodeAt(i))|0; return h; }
+function escape(s){ return String(s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+</script>
+<script src="i18n.js"></script>
+<script src="nav.js"></script>
+</body>
+</html>

--- a/web/nav.js
+++ b/web/nav.js
@@ -57,6 +57,11 @@
     { href: 'hub.html', label: '🧭 Journeys' },
     { href: 'galaxy3d.html', label: '🌌 Galaxy 3D' },
     { group: '🆕 New', items: [
+      ['voice.html', '🎙️ Voice Mode'],
+      ['capture.html', '📷 Live Capture'],
+      ['video.html', '🎬 Video export'],
+      ['wartable.html', '⚔️ The War Table'],
+      ['holo.html', '🎴 Holo Cards'],
       ['make.html', '🏭 Make it real'],
       ['meeting.html', '🗒️ Meeting → artifacts'],
       ['data.html', '📊 Bring your own data'],

--- a/web/video.html
+++ b/web/video.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Video export — turn any output into a shareable animated clip</title>
+<meta name="description" content="Paste a pitch, a one-pager, or any skill output and render it into a short animated video (.webm) with motion, counting numbers, a soundtrack, and your brand colour — ready to post. All in your browser, no upload." />
+<link rel="stylesheet" href="styles.css" />
+<script src="brandkit.js"></script>
+<style>
+  .vd-wrap { max-width: 860px; margin: 0 auto; padding: 14px 22px 60px; }
+  .vd-lead { color: var(--muted); font-size: 15px; line-height: 1.55; }
+  textarea { width: 100%; box-sizing: border-box; min-height: 150px; padding: 12px 14px; background: var(--panel); border: 1px solid var(--border); border-radius: 12px; color: var(--text); font-family: inherit; font-size: 14px; line-height: 1.5; }
+  .row { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin: 12px 0; }
+  input[type=text] { padding: 9px 12px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 14px; }
+  select { padding: 9px 12px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; color: var(--text); }
+  #stage { width: 100%; max-width: 640px; border-radius: 14px; border: 1px solid var(--border); background:#000; display:block; margin: 12px auto; aspect-ratio: 16/9; }
+  #preview { width: 100%; max-width: 640px; border-radius: 14px; display:none; margin: 12px auto; }
+  .warn { font-size: 12.5px; color: var(--muted); }
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
+    <div class="brand-text"><h1>Video export</h1><p class="tagline">Any output → a short animated clip you can post.</p></div>
+  </div>
+</header>
+<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+<div class="key-note">🔒 Rendered entirely in your browser (canvas + MediaRecorder). Nothing is uploaded. Uses your Brand Kit colour if set.</div>
+
+<div class="vd-wrap">
+  <p class="vd-lead">Paste a pitch, a one-pager, a launch brief, or any skill output. The renderer pulls the headline, the big numbers, and the key takeaways and turns them into a **motion graphic** — counting figures, a soundtrack, your brand colour — as a <strong>.webm</strong> you can drop on LinkedIn or X.</p>
+  <div class="row">
+    <input id="title" type="text" placeholder="Title (optional — else taken from the first heading)" style="flex:1;min-width:220px" />
+    <select id="ratio"><option value="16:9">16:9 (landscape)</option><option value="1:1">1:1 (square)</option><option value="9:16">9:16 (vertical)</option></select>
+    <select id="sound"><option value="on">🔊 soundtrack on</option><option value="off">🔇 silent</option></select>
+  </div>
+  <textarea id="src" placeholder="Paste the content here — works best with a heading, some **42%**-style numbers, and a few '- bullet' takeaways."></textarea>
+  <div class="row">
+    <button id="renderBtn" class="primary" type="button">🎬 Render video</button>
+    <button id="dlBtn" class="ghost" type="button" hidden>⬇ Download .webm</button>
+    <span id="status" class="status"></span>
+  </div>
+  <canvas id="stage" width="1280" height="720"></canvas>
+  <video id="preview" controls playsinline></video>
+  <p class="warn" id="compat" hidden></p>
+</div>
+
+<script>
+const el=(id)=>document.getElementById(id);
+let rendering=false, LASTURL='';
+init();
+function init(){
+  el('renderBtn').addEventListener('click',render);
+  el('dlBtn').addEventListener('click',()=>{ if(!LASTURL)return; const a=document.createElement('a'); a.href=LASTURL; a.download='pm-skills-video.webm'; document.body.appendChild(a); a.click(); a.remove(); });
+  if(!('MediaRecorder' in window)){ el('compat').hidden=false; el('compat').textContent='Your browser can’t record canvas video. Try Chrome or Edge.'; el('renderBtn').disabled=true; }
+}
+function clean(s){ return s.replace(/\*\*(.+?)\*\*/g,'$1').replace(/[*`_#>]/g,'').replace(/\[(.+?)\]\(.+?\)/g,'$1').trim(); }
+function parse(md){
+  const lines=md.split('\n').map(l=>l.trim());
+  const title=el('title').value.trim() || clean(lines.find(l=>/^#\s/.test(l))||'') || 'PM Skills';
+  const stats=[]; const seen={};
+  const re=/(?:\*\*|`)?(\$?\d[\d,]*\.?\d*\s*[%x×]?[KMB]?)(?:\*\*|`)?\s*(?:[—:\-–]\s*|\()([A-Za-z][^\n.|)]{2,40})/g; let m;
+  while((m=re.exec(md))&&stats.length<4){ const k=m[1]+m[2]; if(seen[k])continue; seen[k]=1; stats.push({n:m[1].trim(),label:clean(m[2])}); }
+  const takeaways=lines.filter(l=>/^[-*+]\s+/.test(l)).slice(0,4).map(l=>clean(l.replace(/^[-*+]\s+/,''))).filter(Boolean);
+  return { title, stats, takeaways };
+}
+function dims(){ const r=el('ratio').value; return r==='1:1'?[1080,1080]:r==='9:16'?[720,1280]:[1280,720]; }
+function accent(){ const b=(window.PMBrand&&PMBrand.get())||{}; return b.accent||'#d9605a'; }
+function hexToRgb(h){ h=h.replace('#',''); if(h.length===3)h=h.split('').map(c=>c+c).join(''); const n=parseInt(h,16); return [n>>16&255,n>>8&255,n&255]; }
+
+async function render(){
+  const md=el('src').value.trim(); if(md.length<20) return setStatus('Paste some content first.',true);
+  if(rendering) return;
+  const data=parse(md); const [W,H]=dims(); const c=el('stage'); c.width=W; c.height=H;
+  const x=c.getContext('2d'); const ac=hexToRgb(accent());
+  el('preview').style.display='none'; el('dlBtn').hidden=true; setStatus('Rendering…'); rendering=true; el('renderBtn').disabled=true;
+
+  // audio track (a soft evolving pad) so the webm carries sound
+  let audioCtx=null, dest=null;
+  if(el('sound').value==='on'){ try{ audioCtx=new (window.AudioContext||window.webkitAudioContext)(); dest=audioCtx.createMediaStreamDestination();
+    [220,277,330].forEach((f,i)=>{ const o=audioCtx.createOscillator(),g=audioCtx.createGain(); o.type='sine'; o.frequency.value=f; g.gain.value=0.0; o.connect(g); g.connect(dest); o.start(); g.gain.setValueAtTime(0,audioCtx.currentTime); g.gain.linearRampToValueAtTime(0.05,audioCtx.currentTime+1.2+i*0.2); }); }catch(e){} }
+
+  const cstream=c.captureStream(30);
+  if(dest) dest.stream.getAudioTracks().forEach(t=>cstream.addTrack(t));
+  const mime=['video/webm;codecs=vp9','video/webm;codecs=vp8','video/webm'].find(m=>MediaRecorder.isTypeSupported(m))||'video/webm';
+  const rec=new MediaRecorder(cstream,{mimeType:mime, videoBitsPerSecond:4_000_000}); const chunks=[];
+  rec.ondataavailable=e=>{ if(e.data.size)chunks.push(e.data); };
+  const done=new Promise(res=>{ rec.onstop=res; });
+  rec.start();
+
+  const DUR=Math.min(20000, 6000+data.stats.length*1800+data.takeaways.length*900);
+  const t0=performance.now();
+  await new Promise(resolve=>{
+    function frame(t){
+      const e=t-t0; const p=e/DUR;
+      paint(x,W,H,ac,data,e);
+      if(e>=DUR){ resolve(); return; }
+      requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+  });
+  rec.stop(); await done; if(audioCtx) try{ audioCtx.close(); }catch(e){}
+  const blob=new Blob(chunks,{type:mime}); if(LASTURL)URL.revokeObjectURL(LASTURL); LASTURL=URL.createObjectURL(blob);
+  const pv=el('preview'); pv.src=LASTURL; pv.style.display='block'; el('dlBtn').hidden=false;
+  setStatus('Done — preview + download below ('+(blob.size/1e6).toFixed(1)+' MB).'); rendering=false; el('renderBtn').disabled=false;
+  if(window.pmTrack) pmTrack('video/render');
+}
+
+// Scene painter driven by elapsed ms.
+function paint(x,W,H,ac,data,e){
+  // animated gradient background
+  const g=x.createLinearGradient(0,0,W,H);
+  const s=0.5+0.5*Math.sin(e/2600);
+  g.addColorStop(0,`rgb(${ac[0]*0.16|0},${ac[1]*0.16|0},${ac[2]*0.18|0})`);
+  g.addColorStop(1,`rgb(${8+ac[0]*0.08*s|0},${10+ac[1]*0.06*s|0},${14})`);
+  x.fillStyle=g; x.fillRect(0,0,W,H);
+  // moving accent glow
+  x.save(); const gx=W*(0.3+0.4*Math.sin(e/3000)), gy=H*(0.35+0.3*Math.cos(e/3700));
+  const rg=x.createRadialGradient(gx,gy,0,gx,gy,W*0.5); rg.addColorStop(0,`rgba(${ac[0]},${ac[1]},${ac[2]},0.28)`); rg.addColorStop(1,'rgba(0,0,0,0)'); x.fillStyle=rg; x.fillRect(0,0,W,H); x.restore();
+
+  const U=W/1280; // scale unit
+  x.textAlign='center'; x.fillStyle='#fff';
+  const seg=1600; // ms per stat
+  const titleEnd=2200, statsStart=2200, statsDur=data.stats.length*seg, takeStart=statsStart+statsDur;
+
+  if(e<statsStart){ // title card
+    const a=Math.min(1,e/500)*Math.min(1,(statsStart-e)/500+1);
+    x.globalAlpha=Math.max(0,Math.min(1,a));
+    x.font=`700 ${64*U}px Inter,Arial,sans-serif`;
+    wrap(x, data.title, W/2, H/2-10*U, W*0.82, 74*U);
+    x.globalAlpha=1;
+  } else if(e<takeStart && data.stats.length){
+    const idx=Math.min(data.stats.length-1, Math.floor((e-statsStart)/seg));
+    const local=(e-statsStart)-idx*seg; const st=data.stats[idx];
+    const appear=Math.min(1,local/400);
+    x.globalAlpha=appear;
+    // big number (count up)
+    x.fillStyle=`rgb(${ac[0]},${ac[1]},${ac[2]})`;
+    x.font=`800 ${150*U}px Inter,Arial,sans-serif`;
+    x.fillText(countUp(st.n, local), W/2, H/2);
+    x.fillStyle='#fff'; x.font=`600 ${40*U}px Inter,Arial,sans-serif`;
+    wrap(x, st.label, W/2, H/2+70*U, W*0.8, 46*U);
+    x.globalAlpha=1;
+  } else { // takeaways
+    x.font=`700 ${44*U}px Inter,Arial,sans-serif`; x.fillStyle=`rgb(${ac[0]},${ac[1]},${ac[2]})`;
+    x.fillText('Key takeaways', W/2, H*0.22);
+    x.fillStyle='#fff'; x.textAlign='left'; x.font=`500 ${34*U}px Inter,Arial,sans-serif`;
+    const lt=e-takeStart;
+    data.takeaways.forEach((t,i)=>{ if(lt>i*700){ const a=Math.min(1,(lt-i*700)/400); x.globalAlpha=a; wrap(x,'•  '+t, W*0.12, H*0.34+i*70*U, W*0.76, 44*U, true); } });
+    x.globalAlpha=1; x.textAlign='center';
+  }
+  // footer brand
+  x.fillStyle='rgba(255,255,255,0.55)'; x.font=`500 ${22*U}px Inter,Arial,sans-serif`; x.textAlign='center';
+  x.fillText('mohitagw15856.github.io/pm-claude-skills', W/2, H-30*U);
+}
+function countUp(n, ms){ const m=n.match(/([\d,.]+)/); if(!m) return n; const target=parseFloat(m[1].replace(/,/g,'')); const p=Math.min(1,ms/700); const val=target*(0.2+0.8*(1-Math.pow(1-p,3))); const dec=(m[1].split('.')[1]||'').length; return n.replace(m[1], (dec?val.toFixed(dec):Math.round(val)).toLocaleString()); }
+function wrap(x,text,cx,cy,maxW,lh,left){
+  const words=text.split(' '); let line='',lines=[];
+  for(const w of words){ const test=line?line+' '+w:w; if(x.measureText(test).width>maxW&&line){ lines.push(line); line=w; } else line=test; }
+  if(line)lines.push(line);
+  lines.slice(0,3).forEach((ln,i)=>{ x.fillText(ln, cx, cy+i*lh - (left?0:(lines.length-1)*lh/2)); });
+}
+function setStatus(m,err){ const s=el('status'); s.textContent=m; s.className='status'+(err?' err':''); }
+</script>
+<script src="i18n.js"></script>
+<script src="nav.js"></script>
+</body>
+</html>

--- a/web/voice.html
+++ b/web/voice.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Voice Mode — talk to the library, hands-free</title>
+<meta name="description" content="Talk to 515 professional skills out loud and hear the answer back — a hands-free voice agent fronted by a living orb that listens, thinks, and speaks. Runs entirely in your browser." />
+<link rel="stylesheet" href="styles.css" />
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js" integrity="sha384-NNQgBjjuhtXzPmmy4gurS5X7P4uTt1DThyevz4Ua0IVK5+kazYQI1W27JHjbbxQz" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js" integrity="sha384-3HPB1XT51W3gGRxAmZ+qbZwRpRlFQL632y8x+adAqCr4Wp3TaWwCLSTAJJKbyWEK" crossorigin="anonymous"></script>
+<script src="providers.js"></script>
+<style>
+  .v-wrap { max-width: 720px; margin: 0 auto; padding: 10px 22px 60px; text-align: center; }
+  #orb { width: min(78vw, 340px); height: min(78vw, 340px); display: block; margin: 8px auto 4px; cursor: pointer; }
+  .v-state { font-size: 13px; letter-spacing: .18em; text-transform: uppercase; color: var(--muted); min-height: 18px; }
+  .v-pick { display: inline-flex; gap: 8px; align-items: center; margin: 6px 0 4px; }
+  .v-pick select { padding: 8px 11px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 13.5px; }
+  .v-transcript { max-width: 620px; margin: 12px auto; text-align: left; }
+  .bubble { padding: 10px 14px; border-radius: 14px; margin: 8px 0; font-size: 14px; line-height: 1.55; }
+  .bubble.me { background: var(--accent); color: #1a1207; border-bottom-right-radius: 4px; max-width: 80%; margin-left: auto; }
+  .bubble.ai { background: var(--panel); border: 1px solid var(--border); border-bottom-left-radius: 4px; }
+  .v-actions { margin: 6px 0; display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
+  .warn { font-size: 12.5px; color: var(--muted); }
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
+    <div class="brand-text"><h1>Voice Mode</h1><p class="tagline">Talk to the library. It talks back.</p></div>
+  </div>
+  <div class="key-area">
+    <select id="provider" title="Model provider"><option value="gemini">Gemini (free key)</option><option value="webllm">In-browser (no key)</option><option value="anthropic">Claude</option><option value="openai">OpenAI</option><option value="ollama">Ollama (local)</option></select>
+    <div class="key-field"><input id="apiKey" type="password" placeholder="sk-ant-… (your Anthropic API key)" autocomplete="off" /><button id="keyToggle" type="button" class="show-toggle">Show</button></div>
+    <select id="model" title="Model"><option value="claude-opus-4-8">Opus 4.8</option><option value="claude-sonnet-4-6" selected>Sonnet 4.6</option><option value="claude-haiku-4-5-20251001">Haiku 4.5</option></select>
+  </div>
+</header>
+<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+<div class="key-note">🔒 Your voice is transcribed in your browser (Web Speech). Only the text goes to your chosen provider — no audio is uploaded to us.</div>
+
+<div class="v-wrap">
+  <canvas id="orb" width="680" height="680" aria-label="voice orb"></canvas>
+  <div class="v-state" id="state">tap the orb to talk</div>
+  <div class="v-pick">
+    <span class="warn">Answer as</span>
+    <select id="skillSelect"><option value="">🧠 Assistant (any topic)</option></select>
+    <label class="warn"><input type="checkbox" id="handsfree"> hands-free</label>
+  </div>
+  <div class="v-actions">
+    <button id="talkBtn" class="primary" type="button">🎙️ Hold to talk</button>
+    <button id="stopBtn" class="ghost" type="button" hidden>Stop</button>
+    <button id="muteBtn" class="ghost" type="button">🔊 Voice on</button>
+  </div>
+  <p class="warn" id="compat" hidden>Speech recognition needs Chrome, Edge, or Safari. You can still type in other browsers.</p>
+  <input id="typeIn" type="text" placeholder="…or type here and press Enter" style="width:100%;max-width:620px;box-sizing:border-box;margin-top:6px;padding:10px 13px;background:var(--panel-2);border:1px solid var(--border);border-radius:10px;color:var(--text)" />
+  <div class="v-transcript" id="transcript"></div>
+</div>
+
+<script>
+const el=(id)=>document.getElementById(id);
+let controller=null, speakOn=true, history=[], recog=null, listening=false, handsfree=false;
+let state='idle', analyser=null, micStream=null, level=0;
+const COLORS={ idle:[120,130,150], listening:[86,150,255], thinking:[230,170,60], speaking:[80,210,140] };
+
+init();
+function init(){
+  PMProviders.initProviderUI();
+  el('keyToggle').addEventListener('click',()=>{const f=el('apiKey');const s=f.type==='password';f.type=s?'text':'password';el('keyToggle').textContent=s?'Hide':'Show';});
+  el('orb').addEventListener('click',toggleTalk);
+  el('talkBtn').addEventListener('mousedown',startListen); el('talkBtn').addEventListener('mouseup',stopListen);
+  el('talkBtn').addEventListener('touchstart',(e)=>{e.preventDefault();startListen();}); el('talkBtn').addEventListener('touchend',(e)=>{e.preventDefault();stopListen();});
+  el('stopBtn').addEventListener('click',()=>{ if(controller)controller.abort(); window.speechSynthesis&&speechSynthesis.cancel(); setState('idle'); });
+  el('muteBtn').addEventListener('click',()=>{ speakOn=!speakOn; el('muteBtn').textContent=speakOn?'🔊 Voice on':'🔇 Voice off'; if(!speakOn)speechSynthesis.cancel(); });
+  el('handsfree').addEventListener('change',(e)=>{ handsfree=e.target.checked; });
+  el('typeIn').addEventListener('keydown',(e)=>{ if(e.key==='Enter'&&e.target.value.trim()){ ask(e.target.value.trim()); e.target.value=''; } });
+  setupRecog();
+  loadSkills();
+  requestAnimationFrame(draw);
+}
+async function loadSkills(){
+  try{ const s=(await (await fetch('skills.json')).json()).skills; s.sort((a,b)=>a.title.localeCompare(b.title)); window.SKILLS=s; for(const k of s){ const o=document.createElement('option'); o.value=k.name; o.textContent=k.title; el('skillSelect').appendChild(o);} }catch(e){}
+}
+function setState(s){ state=s; el('state').textContent = s==='idle'?'tap the orb to talk':s==='listening'?'listening…':s==='thinking'?'thinking…':'speaking…'; }
+
+// ---- Web Speech recognition ----
+function setupRecog(){
+  const SR=window.SpeechRecognition||window.webkitSpeechRecognition;
+  if(!SR){ el('compat').hidden=false; return; }
+  recog=new SR(); recog.lang='en-US'; recog.interimResults=false; recog.maxAlternatives=1;
+  recog.onresult=(e)=>{ const t=e.results[0][0].transcript.trim(); if(t) ask(t); };
+  recog.onend=()=>{ listening=false; if(state==='listening') setState('idle'); stopMic(); };
+  recog.onerror=()=>{ listening=false; setState('idle'); stopMic(); };
+}
+function toggleTalk(){ if(listening) stopListen(); else startListen(); }
+async function startListen(){
+  if(!recog){ el('typeIn').focus(); return; }
+  if(listening||state==='thinking') return;
+  window.speechSynthesis&&speechSynthesis.cancel();
+  try{ await startMic(); }catch(e){}
+  try{ recog.start(); listening=true; setState('listening'); }catch(e){}
+}
+function stopListen(){ if(recog&&listening){ try{ recog.stop(); }catch(e){} } }
+async function startMic(){
+  if(micStream) return;
+  micStream=await navigator.mediaDevices.getUserMedia({audio:true});
+  const ac=new (window.AudioContext||window.webkitAudioContext)();
+  const src=ac.createMediaStreamSource(micStream); analyser=ac.createAnalyser(); analyser.fftSize=256; src.connect(analyser);
+}
+function stopMic(){ if(micStream){ micStream.getTracks().forEach(t=>t.stop()); micStream=null; analyser=null; level=0; } }
+
+// ---- Ask a skill / assistant ----
+async function ask(text){
+  const key=el('apiKey').value.trim();
+  addBubble('me',text);
+  if(!key){ addBubble('ai','Add your provider key (top-right) so I can answer.'); return; }
+  const sk=window.SKILLS&&window.SKILLS.find(s=>s.name===el('skillSelect').value);
+  const system=(sk? sk.instructions+'\n\n' : 'You are a sharp, friendly professional assistant with command of a large library of professional skills. ')
+    +'This is a VOICE conversation: reply in a natural, spoken style — concise, no markdown headings, no bullet symbols, short sentences a person can listen to. Get to the point.';
+  setState('thinking'); el('stopBtn').hidden=false; controller=new AbortController();
+  const b=addBubble('ai','…');
+  try{
+    const acc=await PMProviders.stream({key,model:el('model').value,system,userMessage:text,signal:controller.signal,onDelta:(a)=>{ b.textContent=a; }});
+    b.innerHTML=DOMPurify.sanitize(marked.parse(acc));
+    if(window.pmTrack) pmTrack('voice/ask');
+    speak(acc);
+  }catch(e){ b.textContent='⚠️ '+(e.name==='AbortError'?'stopped':(e.message||'failed')); setState('idle'); }
+  finally{ el('stopBtn').hidden=true; controller=null; }
+}
+function addBubble(role,text){ const d=document.createElement('div'); d.className='bubble '+role; d.textContent=text; el('transcript').appendChild(d); d.scrollIntoView({behavior:'smooth',block:'end'}); return d; }
+
+// ---- TTS ----
+function speak(text){
+  if(!speakOn||!window.speechSynthesis){ setState('idle'); maybeReloop(); return; }
+  const plain=text.replace(/[#*`_>|]/g,'').replace(/\[(.+?)\]\(.+?\)/g,'$1').slice(0,1200);
+  const u=new SpeechSynthesisUtterance(plain); u.rate=1.03; u.pitch=1;
+  const vs=speechSynthesis.getVoices(); const pref=vs.find(v=>/Google US English|Samantha|Microsoft Aria|Jenny/i.test(v.name))||vs.find(v=>v.lang.startsWith('en')); if(pref)u.voice=pref;
+  u.onstart=()=>setState('speaking'); u.onend=()=>{ setState('idle'); maybeReloop(); };
+  speechSynthesis.cancel(); speechSynthesis.speak(u);
+}
+function maybeReloop(){ if(handsfree && recog) setTimeout(()=>startListen(), 500); }
+
+// ---- The living orb (canvas) ----
+function draw(t){
+  const c=el('orb'), x=c.getContext('2d'), W=c.width, H=c.height, cx=W/2, cy=H/2;
+  x.clearRect(0,0,W,H);
+  if(analyser){ const a=new Uint8Array(analyser.frequencyBinCount); analyser.getByteFrequencyData(a); let s=0; for(let i=0;i<a.length;i++)s+=a[i]; level=level*0.8+(s/a.length/255)*0.2; }
+  else { level*=0.94; }
+  const base=COLORS[state]||COLORS.idle;
+  const time=t/1000;
+  const react = state==='listening'? level*1.4 : state==='speaking'? (0.5+0.5*Math.sin(time*7)) : state==='thinking'? (0.5+0.5*Math.sin(time*3)) : 0.12;
+  const R=W*0.30*(1+react*0.16);
+  // glow
+  const g=x.createRadialGradient(cx,cy,R*0.2,cx,cy,R*1.7);
+  g.addColorStop(0,`rgba(${base[0]},${base[1]},${base[2]},0.55)`); g.addColorStop(1,'rgba(0,0,0,0)');
+  x.fillStyle=g; x.beginPath(); x.arc(cx,cy,R*1.7,0,7); x.fill();
+  // rippling rings
+  for(let k=0;k<4;k++){
+    const rr=R*(1+k*0.14)+Math.sin(time*2+k)*8*(0.4+react);
+    x.beginPath();
+    for(let i=0;i<=64;i++){ const ang=i/64*Math.PI*2; const wob=Math.sin(ang*5+time*3+k)*R*0.03*(0.5+react); const r=rr+wob; const px=cx+Math.cos(ang)*r, py=cy+Math.sin(ang)*r; i?x.lineTo(px,py):x.moveTo(px,py); }
+    x.closePath(); x.strokeStyle=`rgba(${base[0]},${base[1]},${base[2]},${0.5-k*0.1})`; x.lineWidth=2; x.stroke();
+  }
+  // core
+  const cg=x.createRadialGradient(cx-R*0.25,cy-R*0.25,R*0.1,cx,cy,R);
+  cg.addColorStop(0,`rgba(255,255,255,0.9)`); cg.addColorStop(0.3,`rgba(${base[0]},${base[1]},${base[2]},0.95)`); cg.addColorStop(1,`rgba(${base[0]*0.4|0},${base[1]*0.4|0},${base[2]*0.4|0},0.9)`);
+  x.fillStyle=cg; x.beginPath(); x.arc(cx,cy,R,0,7); x.fill();
+  requestAnimationFrame(draw);
+}
+</script>
+<script src="i18n.js"></script>
+<script src="nav.js"></script>
+</body>
+</html>

--- a/web/wartable.html
+++ b/web/wartable.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>The War Table — watch two AIs negotiate in real time</title>
+<meta name="description" content="Set a scenario and watch two AI agents negotiate or compete live — moves landing one by one, a tension meter swinging, the deal converging or collapsing before your eyes. A spectator sport for professional judgment." />
+<link rel="stylesheet" href="styles.css" />
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.0/marked.min.js" integrity="sha384-NNQgBjjuhtXzPmmy4gurS5X7P4uTt1DThyevz4Ua0IVK5+kazYQI1W27JHjbbxQz" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.9/dist/purify.min.js" integrity="sha384-3HPB1XT51W3gGRxAmZ+qbZwRpRlFQL632y8x+adAqCr4Wp3TaWwCLSTAJJKbyWEK" crossorigin="anonymous"></script>
+<script src="providers.js"></script>
+<style>
+  .wt-wrap { max-width: 900px; margin: 0 auto; padding: 12px 22px 60px; }
+  .setup { display: flex; gap: 10px; flex-wrap: wrap; align-items: center; margin: 12px 0; }
+  .setup select, .setup input { padding: 9px 12px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 14px; }
+  .meters { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin: 14px 0; }
+  .meter { border: 1px solid var(--border); border-radius: 12px; padding: 10px 14px; background: var(--panel); }
+  .meter .lab { font-size: 11px; text-transform: uppercase; letter-spacing: 1px; color: var(--muted); }
+  .bar { height: 12px; border-radius: 8px; background: var(--panel-2); overflow: hidden; margin-top: 6px; }
+  .bar > i { display: block; height: 100%; border-radius: 8px; transition: width .6s ease; }
+  .board { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 12px; }
+  .side { border: 1px solid var(--border); border-radius: 14px; padding: 12px; background: var(--panel); min-height: 120px; }
+  .side h3 { margin: 0 0 4px; font-size: 15px; display:flex; align-items:center; gap:8px; }
+  .avatar { width: 30px; height: 30px; border-radius: 50%; display:inline-flex; align-items:center; justify-content:center; font-size:16px; }
+  .move { background: var(--panel-2); border-radius: 10px; padding: 9px 12px; margin: 8px 0; font-size: 13.5px; line-height: 1.5; animation: pop .35s ease; }
+  .side.active { box-shadow: 0 0 0 2px var(--accent); }
+  @keyframes pop { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
+  .verdict { border: 1px solid var(--accent); border-radius: 14px; padding: 14px 16px; margin-top: 14px; }
+  .warn { font-size: 12.5px; color: var(--muted); }
+</style>
+</head>
+<body>
+<header class="topbar">
+  <div class="brand">
+    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
+    <div class="brand-text"><h1>The War Table</h1><p class="tagline">Two AIs. One deal. Watch it land — or collapse.</p></div>
+  </div>
+  <div class="key-area">
+    <select id="provider" title="Model provider"><option value="gemini">Gemini (free key)</option><option value="webllm">In-browser (no key)</option><option value="anthropic">Claude</option><option value="openai">OpenAI</option><option value="ollama">Ollama (local)</option></select>
+    <div class="key-field"><input id="apiKey" type="password" placeholder="sk-ant-… (your key)" autocomplete="off" /><button id="keyToggle" type="button" class="show-toggle">Show</button></div>
+    <select id="model" title="Model"><option value="claude-opus-4-8">Opus 4.8</option><option value="claude-sonnet-4-6" selected>Sonnet 4.6</option><option value="claude-haiku-4-5-20251001">Haiku 4.5</option></select>
+  </div>
+</header>
+<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+<div class="key-note">🔒 Your key stays in your browser. Each move is one model call to your chosen provider.</div>
+
+<div class="wt-wrap">
+  <div class="setup">
+    <span class="warn">Scenario</span>
+    <select id="scenario"></select>
+    <span class="warn">rounds</span>
+    <select id="rounds"><option>3</option><option selected>4</option><option>5</option></select>
+    <button id="startBtn" class="primary" type="button">▶ Start the standoff</button>
+    <button id="stopBtn" class="ghost" type="button" hidden>Stop</button>
+    <span id="status" class="status"></span>
+  </div>
+
+  <div class="meters">
+    <div class="meter"><div class="lab">Tension</div><div class="bar"><i id="tension" style="width:20%;background:linear-gradient(90deg,#3fb950,#f85149)"></i></div></div>
+    <div class="meter"><div class="lab">Deal proximity</div><div class="bar"><i id="deal" style="width:10%;background:linear-gradient(90deg,#30363d,#3fb950)"></i></div></div>
+  </div>
+
+  <div class="board">
+    <div class="side" id="sideA"><h3><span class="avatar" style="background:#1f6feb33">🟦</span><span id="nameA"></span></h3><div id="movesA"></div></div>
+    <div class="side" id="sideB"><h3><span class="avatar" style="background:#f8514933">🟥</span><span id="nameB"></span></h3><div id="movesB"></div></div>
+  </div>
+
+  <div class="verdict" id="verdict" hidden></div>
+</div>
+
+<script>
+const el=(id)=>document.getElementById(id);
+let controller=null, tension=20, deal=10;
+const SCENARIOS=[
+  { id:'salary', name:'Salary negotiation', topic:'a job offer negotiation',
+    A:{n:'Candidate',goal:'Push base from $145k toward $170k + more equity; you have a competing offer at $160k but prefer this team.'},
+    B:{n:'Hiring Manager',goal:'Budget tops out at $160k base; you can flex equity and signing bonus, not base. You want this hire but must stay fair to the band.'} },
+  { id:'vendor', name:'Vendor renewal', topic:'a SaaS contract renewal',
+    A:{n:'Customer (VP Ops)',goal:'Cut the renewal 20% and add an SLA; you have a cheaper competitor quote but migration is painful.'},
+    B:{n:'Account Exec',goal:'Hold price within 5%; you can give SLA credits and a longer term. Losing this logo hurts your quarter.'} },
+  { id:'acq', name:'Acquisition price', topic:'an acquisition price negotiation',
+    A:{n:'Founder',goal:'Anchor at 6x ARR ($60M); you can accept 4.5x if earnout is fair. You have modest runway, not desperate.'},
+    B:{n:'Corp Dev',goal:'Target 3.5x ARR; you can reach 4.5x with an earnout tied to retention. Board wants discipline.'} },
+  { id:'partner', name:'Partnership terms', topic:'a co-marketing partnership',
+    A:{n:'Startup BD',goal:'Get equal logo placement and a revenue share; you bring the hotter brand but less scale.'},
+    B:{n:'Enterprise BD',goal:'Give distribution but keep control of the customer and cap rev-share at 10%. You bring the scale.'} },
+];
+init();
+function init(){
+  PMProviders.initProviderUI();
+  el('keyToggle').addEventListener('click',()=>{const f=el('apiKey');const s=f.type==='password';f.type=s?'text':'password';el('keyToggle').textContent=s?'Hide':'Show';});
+  for(const s of SCENARIOS){ const o=document.createElement('option'); o.value=s.id; o.textContent=s.name; el('scenario').appendChild(o); }
+  el('startBtn').addEventListener('click',start);
+  el('stopBtn').addEventListener('click',()=>controller&&controller.abort());
+}
+function persona(sc, me, them){ return `You are ${me.n} in ${sc.topic}. Your private objective: ${me.goal}\nYou are negotiating against ${them.n}. Stay in character. Respond with your NEXT move only — 1 to 3 sentences, natural spoken negotiation, no stage directions, no markdown. Make a concrete offer, concession, or push. If a fair deal is on the table, you may accept and say so plainly.`; }
+function setMeter(id,v){ el(id).style.width=Math.max(2,Math.min(100,v))+'%'; }
+function scoreMove(text){ // crude live sentiment for the meters
+  const t=text.toLowerCase();
+  const warm=(t.match(/\b(agree|accept|deal|fair|works for me|happy to|great|yes|glad|appreciate|meet you|compromise|sounds good)\b/g)||[]).length;
+  const cold=(t.match(/\b(no|can't|cannot|won't|refuse|walk|final|non-negotiable|unacceptable|too (low|high)|not (enough|possible)|deadline)\b/g)||[]).length;
+  tension=Math.max(5,Math.min(100, tension + cold*11 - warm*9));
+  deal=Math.max(2,Math.min(100, deal + warm*16 - cold*7 + 4));
+  setMeter('tension',tension); setMeter('deal',deal);
+  return /\b(accept|we have a deal|i'll take it|done deal|agreed)\b/i.test(text);
+}
+async function start(){
+  const key=el('apiKey').value.trim(); if(!key) return setStatus('Enter your provider key.',true);
+  const sc=SCENARIOS.find(s=>s.id===el('scenario').value); const rounds=+el('rounds').value;
+  el('nameA').textContent=sc.A.n; el('nameB').textContent=sc.B.n; el('movesA').innerHTML=''; el('movesB').innerHTML=''; el('verdict').hidden=true;
+  tension=20; deal=10; setMeter('tension',tension); setMeter('deal',deal);
+  el('startBtn').disabled=true; el('stopBtn').hidden=false; controller=new AbortController();
+  if(window.pmTrack) pmTrack('wartable/'+sc.id);
+  let transcript=[]; let closed=false;
+  try{
+    for(let r=0;r<rounds && !closed;r++){
+      for(const who of ['A','B']){
+        if(closed) break;
+        const me=sc[who], them=sc[who==='A'?'B':'A'];
+        el('side'+who).classList.add('active'); el('side'+(who==='A'?'B':'A')).classList.remove('active');
+        const bubble=addMove(who,'…');
+        const convo=transcript.length? transcript.map(m=>m.n+': '+m.t).join('\n') : '(you open the negotiation)';
+        setStatus(me.n+' is thinking…');
+        const acc=await PMProviders.stream({key,model:el('model').value,system:persona(sc,me,them),userMessage:'Conversation so far:\n'+convo+'\n\nYour move:',signal:controller.signal,onDelta:(a)=>{bubble.textContent=a;}});
+        bubble.textContent=acc; transcript.push({n:me.n,t:acc});
+        closed=scoreMove(acc);
+        await sleep(400);
+      }
+    }
+    verdict(closed, sc);
+  }catch(e){ setStatus(e.name==='AbortError'?'Stopped.':(e.message||'Failed.'),true); }
+  finally{ el('startBtn').disabled=false; el('stopBtn').hidden=true; el('sideA').classList.remove('active'); el('sideB').classList.remove('active'); controller=null; }
+}
+function addMove(who,text){ const d=document.createElement('div'); d.className='move'; d.textContent=text; el('moves'+who).appendChild(d); d.scrollIntoView({behavior:'smooth',block:'nearest'}); return d; }
+function verdict(closed,sc){ const v=el('verdict'); v.hidden=false;
+  v.innerHTML= closed
+    ? '🤝 <strong>Deal reached.</strong> They found terms both could sign — deal proximity '+Math.round(deal)+'%, tension cooled to '+Math.round(tension)+'%.'
+    : (deal>60? '⏳ <strong>Close, but no signature.</strong> Deal proximity '+Math.round(deal)+'% at the buzzer — one more round might have closed it.'
+              : '💥 <strong>Standoff.</strong> Tension '+Math.round(tension)+'%, deal proximity only '+Math.round(deal)+'%. They talked past each other.');
+  setStatus('Done.');
+}
+const sleep=(ms)=>new Promise(r=>setTimeout(r,ms));
+function setStatus(m,err){ const s=el('status'); s.textContent=m; s.className='status'+(err?' err':''); }
+</script>
+<script src="i18n.js"></script>
+<script src="nav.js"></script>
+</body>
+</html>


### PR DESCRIPTION
First of two "groundbreaking / visually appealing" waves — five futuristic, motion-driven surfaces, all self-contained and client-side on the shared `PMProviders` layer.

### The five
1. **🎙️ Voice Mode** (`voice.html`) — a hands-free voice agent fronted by a living canvas **orb** that listens / thinks / speaks in colour. Web Speech STT + `speechSynthesis` TTS; pick a skill or a free "assistant"; optional hands-free re-loop. *Audio never leaves the browser* — only the transcribed text goes to your provider.
2. **📷 Live Capture** (`capture.html`) — point a camera at a whiteboard / contract / screen / chart and turn the frame into an artifact **live**, with an animated scanning overlay + corner brackets. Uses `PMProviders`' image support (Claude / Gemini / OpenAI vision).
3. **🎬 Video export** (`video.html`) — paste any output and render a shareable animated **`.webm`**: motion graphic, counting numbers, a Web-Audio soundtrack, your Brand-Kit colour — via `canvas.captureStream` + `MediaRecorder`. No upload.
4. **⚔️ The War Table** (`wartable.html`) — watch two AI agents **negotiate live**: moves land one at a time, a **tension meter** and **deal-proximity** bar swing, and it ends in a verdict (deal / close / standoff). Four scenarios (salary, vendor renewal, acquisition, partnership).
5. **🎴 Holo Cards** (`holo.html`) — tear open a **booster pack** and pull tilt-reactive, gyroscope-aware **holographic** skill cards with rarities (foil shimmer, parallax). Every card deep-links into the Playground; single-card share links.

### Notes
- No new npm deps; reuses SRI-pinned marked/DOMPurify + `providers.js` + `export-doc.js`/`brandkit.js` where relevant.
- Graceful degradation: Voice tells non-Chrome users to type; Video feature-detects `MediaRecorder`; Capture reports if a provider/model lacks vision.
- Five entries in the **🆕 New** nav group.
- **Verified** over a local HTTP server with headless Chromium: all five load with their controls present and **zero console errors**. (Camera/mic/model actions run at use-time with the user's permission + key.)

PR 2 of 2 (next) adds the remaining five: Work OS command deck, Prompt-to-App, The Time Machine, Multiplayer Canvas, and WebXR spatial mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_