### PR TITLE
fix(spatial): broken header/nav — use the immersive full-canvas pattern

### DIFF
--- a/web/spatial.html
+++ b/web/spatial.html
@@ -12,20 +12,19 @@
   #space:active { cursor: grabbing; }
   .overlay { position: fixed; z-index: 5; }
   .hint { left: 0; right: 0; bottom: 16px; text-align:center; color: var(--muted); font-size: 12.5px; pointer-events:none; }
-  .hud { top: 70px; left: 16px; display:flex; gap:8px; flex-wrap:wrap; }
+  .hud { top: 14px; right: 16px; display:flex; gap:8px; flex-wrap:wrap; justify-content:flex-end; max-width: 70vw; }
+  #back { position: fixed; z-index: 6; top: 14px; left: 14px; font-size: 13px; color: var(--text); text-decoration: none; background: rgba(16,19,26,.82); border: 1px solid var(--border); border-radius: 999px; padding: 8px 14px; backdrop-filter: blur(6px); display:inline-flex; align-items:center; gap:8px; }
+  #back:hover { border-color: var(--accent); }
+  #back b { font-weight: 700; }
   .hud button, .hud input { background: rgba(20,24,32,.7); border:1px solid var(--border); color: var(--text); border-radius:8px; padding:7px 11px; font-size:13px; backdrop-filter: blur(6px); }
   .tip { position: fixed; z-index: 6; pointer-events:none; background: rgba(10,12,18,.92); border:1px solid var(--accent); border-radius:8px; padding:6px 10px; font-size:12.5px; display:none; max-width:220px; }
   #vrStatus { font-size:12px; color:var(--muted); align-self:center; }
 </style>
 </head>
 <body>
-<header class="topbar">
-  <div class="brand">
-    <img src="assets/product-notes.jpg" alt="Product Notes" class="brand-logo" />
-    <div class="brand-text"><h1>Spatial</h1><p class="tagline">Step inside the library.</p></div>
-  </div>
-</header>
-<nav class="toolbar-nav" id="toolbar" aria-label="Tools"></nav>
+<!-- Immersive full-canvas page (like Galaxy 3D): no shared header/nav bar — the
+     canvas owns the viewport, with a lightweight back pill to return. -->
+<a id="back" href="index.html" title="Back to the Playground">← <b>PM Skills</b> · 🌌 Spatial</a>
 
 <canvas id="space"></canvas>
 <div class="overlay hud">


### PR DESCRIPTION
## The bug
Spatial 3D shipped with the shared `<header>` + `<nav>` bar **and** a full-viewport fixed canvas. The canvas painted over the header (hiding the brand) and the HUD (`search` + `Immersive`) overlapped the nav — so the navigation and header rendered broken.

## The fix
Match the repo's established full-canvas pattern (**Galaxy 3D**), which deliberately goes *immersive*: no shared header/nav bar — the canvas owns the viewport, with a lightweight back pill to return.

- Removed the shared `<header class="topbar">` and `<nav id="toolbar">`.
- Added a **"← PM Skills · 🌌 Spatial"** back pill (top-left).
- Moved the **search + Immersive** HUD to the **top-right** so nothing overlaps.
- Theme init still comes from `nav.js` (kept at the end; it no-ops the nav render when `#toolbar` is absent).

## Verified
Headless Chromium screenshot confirms: back pill present, no `#toolbar`, HUD clear of it, the constellation fills the viewport cleanly, **zero console errors**.

Independent of the open v52 release (#157) — safe to merge on its own.

> Minor follow-up: the `spatial.png` showcase screenshot in #157 shows the old chrome; happy to re-shoot it after both merge so the README image matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_