### PR TITLE
ci: daily ClawHub auto-sync (finish the 515-skill rollout past the 200/day cap)

### DIFF
--- a/.github/workflows/clawhub-sync.yml
+++ b/.github/workflows/clawhub-sync.yml
@@ -1,0 +1,72 @@
+name: Publish to ClawHub
+
+# Keeps the OpenClaw/ClawHub listing in sync with the library. Runs `clawhub
+# sync --all` from the dressed export (exports/openclaw/), which scans every
+# skill and publishes the new/changed ones. ClawHub caps NEW skills at 200 per
+# 24h, so a first full publish of the whole library rolls out over a few days —
+# this daily run just keeps going until everything is live, then no-ops. It also
+# refreshes bodies after each release so ClawHub never serves a stale skill.
+#
+# Setup (one-time): add a repo secret CLAWHUB_TOKEN
+#   ClawHub → account → API token, then GitHub → Settings → Secrets and
+#   variables → Actions → New repository secret named CLAWHUB_TOKEN.
+# Without the secret the job exits cleanly (skips), so it's safe to merge first.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 6 * * *' # daily 06:17 UTC — off the :00 rush
+  # Optional: also run right after a release so bodies refresh immediately.
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clawhub-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      # Secrets can't be used in `if:` expressions, so map it to env and gate in shell.
+      CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Guard — need the token
+        run: |
+          if [ -z "$CLAWHUB_TOKEN" ]; then
+            echo "No CLAWHUB_TOKEN secret set — nothing to do. Add it to enable publishing."
+            echo "SKIP=1" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install ClawHub CLI
+        if: ${{ env.SKIP != '1' }}
+        run: npm i -g clawhub
+
+      - name: Log in
+        if: ${{ env.SKIP != '1' }}
+        run: clawhub login --token "$CLAWHUB_TOKEN" --no-browser --label "github-action"
+
+      - name: Sync (publish new/changed skills)
+        if: ${{ env.SKIP != '1' }}
+        # The CLI has no per-request timeout and retries against the 200/24h rate
+        # limit, so cap the run at 25 min and never fail the job on the cap — the
+        # next scheduled run resumes where this one stopped (sync is idempotent).
+        run: |
+          timeout 1500 clawhub sync \
+            --dir exports/openclaw --all \
+            --source-repo "${{ github.repository }}" \
+            --source-commit "${{ github.sha }}" \
+            --source-ref "${{ github.ref_name }}" || {
+              code=$?
+              echo "sync ended (exit $code) — likely the daily 200-new-skill cap or the 25-min guard."
+              echo "That's expected mid-rollout; tomorrow's run continues. Not failing the job."
+            }

--- a/connectors/openclaw.md
+++ b/connectors/openclaw.md
@@ -45,14 +45,17 @@ clawhub install @mohitagw15856/email-triage      # or: openclaw skills install @
 
 **✅ Tranche 2 published 2026-07-14 (43 skills total live):** the full `pm-decoders` and `pm-simulators` bundles, calculators wave 2 (exit-waterfall, offer-comparison, refinance-breakeven, fire-number), the four v50 singles, and the `pm-lifeadmin` + `pm-personal` bundles — all at v50.0.0, self-contained packages (library-local sections stripped by the export).
 
-**Tranche 3 — publish everything (v53.0.0):** the export already carries all **515** skills; only the first ~43 are live on ClawHub. To publish the rest and refresh the published bodies to the current release, run from the repo root:
+**Tranche 3 — publish everything:** the export already carries all **515** skills. Publish the rest and refresh bodies to the current release with `sync` (run from `exports/openclaw/`, or pass `--dir exports/openclaw`):
 
 ```bash
-clawhub sync --dry-run            # from exports/openclaw/ — review the full plan first (515 folders)
-clawhub sync --all --version 53.0.0
+clawhub sync --dir exports/openclaw --dry-run   # review the full plan first (515 folders)
+clawhub sync --dir exports/openclaw --all \
+  --source-repo mohitagw15856/pm-claude-skills --source-commit "$(git rev-parse HEAD)" --source-ref main
 ```
 
-`clawhub sync` scans the folders and uploads new/changed skills, so it's safe to re-run — existing skills update in place, the rest get created. Re-`sync` after every release so ClawHub never serves a stale body.
+`clawhub sync` scans the folders and uploads new/changed skills, so it's safe to re-run — existing skills update in place, the rest get created. (Note: `sync` has **no** `--version` flag — new skills publish at `1.0.0`; use `--bump patch|minor|major` for updates. The `--source-*` flags are all-or-nothing: pass repo **and** commit together.)
+
+> **⏳ Rate limit — the big-bang publish takes a few days.** ClawHub caps **new** skills at **200 per 24 hours**. A first full publish of 515 therefore rolls out in daily batches (~200 → ~200 → the rest); once the cap is hit, further publishes return `Rate limit: max 200 new skills per 24 hours` and the CLI retries until it stalls — that's expected, not a hang. **This is automated:** the [`clawhub-sync.yml`](../.github/workflows/clawhub-sync.yml) workflow runs `sync --all` daily (set the `CLAWHUB_TOKEN` repo secret) and keeps going until every skill is live, then no-ops. To do it by hand instead, just re-run the `sync` command above once a day until the dry-run shows nothing new.
 
 **Moderation note:** ClawHub may hold a newly-published skill for review before it goes live (e.g. `insurance-claim`). That's a ClawHub-side queue, not a defect — the skill passes this library's own security scan (`npx skillspec-check skills/insurance-claim` → **L3 Trustworthy**), so it's safe to approve from the [ClawHub dashboard](https://clawhub.ai/mohitagw15856).
 


### PR DESCRIPTION
## What does this PR add or change?

Adds a daily GitHub Action that finishes publishing the full library to ClawHub, and fixes the OpenClaw runbook.

## Why

Publishing all 515 skills to ClawHub in one go isn't possible: **ClawHub caps new skills at 200 per 24 hours.** Today's run published the daily max (200), so **243 are live** (43 prior + 200 new) and **272 remain** — they can only go out in future daily windows. Rather than re-run by hand for the next couple of days, this automates it.

## Type of change

- [x] Other: **CI workflow + docs**. No skills changed.

## What's in it

- **`.github/workflows/clawhub-sync.yml`** — runs `clawhub sync --all` (from `exports/openclaw/`) on a **daily schedule** and **on release**:
  - Gated on a `CLAWHUB_TOKEN` repo secret; **no-ops cleanly if the secret is absent**, so it's safe to merge before you add it.
  - **Timeout-wrapped (25 min)** and **never fails the job** on the rate-limit cap — each day it publishes up to 200 more and resumes the next day (sync is idempotent), until everything's live, then it just no-ops.
  - Publishes with source provenance (`github.repository` @ `github.sha`, ref `main`).
- **`connectors/openclaw.md`** runbook fixes:
  - `sync` has **no `--version` flag** (new skills publish at `1.0.0`; updates use `--bump`) — the earlier example was wrong.
  - The `--source-*` flags are all-or-nothing (repo **and** commit together — the thing that made the manual run error out).
  - Documents the **200/24h rate limit** and points at the new workflow.

## Setup you need to do

1. Merge this.
2. **Rotate the ClawHub token** (the one shared in chat is exposed) and add the fresh one as repo secret **`CLAWHUB_TOKEN`** (Settings → Secrets and variables → Actions).
3. Either wait for the 06:17 UTC daily run, or trigger it manually (Actions → *Publish to ClawHub* → Run workflow). It'll top up ~200/day until all 515 are live.

## Testing

- Workflow YAML validated (`yaml.safe_load`).
- Root cause confirmed from the live CLI output: `Rate limit: max 200 new skills per 24 hours`.
- `sync` flag semantics (`--dir`, `--all`, `--source-*`, no `--version`) confirmed against `clawhub sync --help` v0.23.1.

## Anything else the reviewer should know?

The 243 skills already published are correct and carry provenance to `mohitagw15856/pm-claude-skills@8a4cff68`. The `insurance-claim` skill is already live (v50.0.0) and passes `skillspec-check` at **L3 Trustworthy** — its "needs review" is ClawHub's moderation queue, safe to approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_