### PR TITLE
fix(build-exports): tolerate CRLF in SKILL.md frontmatter

### DIFF
--- a/scripts/build-exports.mjs
+++ b/scripts/build-exports.mjs
@@ -207,10 +207,12 @@ const BUNDLE_EMOJI = {
 
 // ── Helpers (shared shape with web/build-skills.mjs) ────────────────────────
 function parseFrontmatter(text) {
-  const m = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  // Tolerate CRLF so skills authored on Windows don't silently export with
+  // an empty description (skillcheck.mjs already tolerates it).
+  const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
   if (!m) return { meta: {}, body: text };
   const meta = {};
-  for (const line of m[1].split('\n')) {
+  for (const line of m[1].split(/\r?\n/)) {
     const kv = line.match(/^(\w[\w-]*):\s*(.*)$/);
     if (kv) {
       let v = kv[2].trim();


### PR DESCRIPTION
Fixes #173.

The parseFrontmatter regex only accepted LF, so a SKILL.md authored on Windows silently exported with `meta = {}` (empty description) — while `skillcheck.mjs` already tolerated CRLF and passed the same file. Aligning the regex with skillcheck's `\r?\n` handling.

**Test**

```bash
# CRLF file: old parser returned {}; new parser returns full meta.
node scripts/build-exports.mjs                 # unchanged output — all shipped skills use LF
node scripts/build-exports.mjs --check         # still passes
```