### PR TITLE
fix(cli): don't pollute parent of a custom --target with claude extras

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -195,7 +195,13 @@ function add(opts) {
     }
     // Claude Code also gets subagents, slash commands, and output-styles.
     if (agent === 'claude') {
-      const claudeRoot = dirname(target);
+      // Extras are siblings of `skills/` (…/.claude/{skills,agents,commands}),
+      // so `dirname(target)` is only correct when the caller kept that layout.
+      // With a custom --target that doesn't end in "skills", we'd otherwise
+      // write agents/commands/output-styles into the parent of target and
+      // pollute an unrelated directory. In that case, drop the extras next to
+      // the skills instead of blindly walking up.
+      const claudeRoot = basename(target) === 'skills' ? dirname(target) : target;
       for (const kind of ['agents', 'commands', 'output-styles']) {
         const src = join(PKG_ROOT, kind);
         if (!existsSync(src)) continue;


### PR DESCRIPTION
Fixes #174.

`add --agent claude` installs `agents/`, `commands/`, and `output-styles/` at `dirname(target)`. That is correct for the default `~/.claude/skills` (extras land next to skills in `~/.claude/`), but with a custom `--target /foo/bar` it silently writes to `/foo/` — a directory the user never named. Only walk up when the target is still shaped like `.../skills`; otherwise place extras inside the target itself.

**Test**

```bash
# default target — behavior unchanged
node bin/cli.mjs add --agent claude --target ~/.claude/skills --dry-run
# → extras go to ~/.claude/agents, ~/.claude/commands, ~/.claude/output-styles

# custom target — extras now land INSIDE it, not in its parent
node bin/cli.mjs add --agent claude --target /tmp/mycustom --dry-run
# → extras go to /tmp/mycustom/agents, /tmp/mycustom/commands, /tmp/mycustom/output-styles
```