### PR TITLE
fix(cli): validate --limit in search instead of silently clamping

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -113,7 +113,17 @@ function search(opts) {
       .filter((s) => s.score >= 0)
       .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
   }
-  const limit = opts.limit ? Math.max(1, parseInt(opts.limit, 10) || 0) : (opts.json ? items.length : 25);
+  let limit;
+  if (opts.limit != null) {
+    const parsed = Number(opts.limit);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      console.error(`Error: --limit must be a positive integer (got "${opts.limit}").`);
+      process.exit(2);
+    }
+    limit = parsed;
+  } else {
+    limit = opts.json ? items.length : 25;
+  }
   const shown = items.slice(0, limit);
 
   if (opts.json) {


### PR DESCRIPTION
Fixes #175.

`search --limit abc`, `--limit 0`, and `--limit -5` all silently returned a single row because `parseInt('abc',10) || 0` → `0`, and `Math.max(1, 0)` → `1`. That masks user typos as 'no other matches'. Reject non-positive-integers up front with a clear error and exit 2.

**Test**

```bash
node bin/cli.mjs search --limit abc   # Error: --limit must be a positive integer (got "abc").
node bin/cli.mjs search --limit 0     # same error
node bin/cli.mjs search decoder --limit 3   # unchanged: 3 rows
```