### PR TITLE
community: add Crew

### DIFF
--- a/COMMUNITY-SKILLS.md
+++ b/COMMUNITY-SKILLS.md
@@ -23,7 +23,7 @@ A directory of **skill repos and packs built by the community** that follow the
 
 | Skill / pack | Author | What it does | Repo |
 |---|---|---|---|
-| _Be the first — open a PR to add yours!_ | | | |
+| [Crew](https://github.com/Honorboxx/crew) | [@Honorboxx](https://github.com/Honorboxx) | Reviewer, debugger and planner agents plus scope/verify/git skills that size a task before coding and turn "done" into observed evidence. | https://github.com/Honorboxx/crew |
 
 <!-- COMMUNITY-SKILLS:ROWS-BELOW
   Add your row directly above this comment, keeping the four columns in order:


### PR DESCRIPTION
Adds one row to the community directory for **Crew** — a small Claude Code agent pack (MIT).

- Repo: https://github.com/Honorboxx/crew
- Contents: 3 agents (`agents/crew-reviewer.md`, `crew-debugger.md`, `crew-planner.md`) and 3 skills with valid `SKILL.md` frontmatter (`skills/crew-scope`, `skills/crew-verify`, `skills/crew-git`).
- License: MIT, public, no paywall on the linked repo.

Checks run locally:

```
$ node scripts/check-community-skills.mjs
Community Skills check — OK (1 listed entry).
```

Disclosure: I'm affiliated with the project — I maintain Crew. It's a young repo, so if your bar for the directory is some adoption history rather than "public repo + valid SKILL.md", I understand and you can close this without hard feelings.

I replaced the `_Be the first_` placeholder row rather than adding beneath it, since the table was otherwise empty — happy to restore the placeholder and append instead if you'd prefer to keep it.
