### PR TITLE
fix(lib/anthropic): tolerate CRLF in parseSkill frontmatter

### DIFF
--- a/bin/lib/anthropic.mjs
+++ b/bin/lib/anthropic.mjs
@@ -64,10 +64,13 @@ export async function complete({ apiKey, model = 'claude-sonnet-4-6', system, me
 
 /** Parse "name: value" YAML-ish frontmatter + body from a SKILL.md string. */
 export function parseSkill(text) {
-  const m = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  // Tolerate CRLF so SKILL.md files authored on Windows parse correctly —
+  // otherwise `run` and `chain` fall through to `text.trim()` and send the raw
+  // '---' frontmatter to the model as part of the system prompt.
+  const m = text.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/);
   const meta = {};
   if (m) {
-    for (const line of m[1].split('\n')) {
+    for (const line of m[1].split(/\r?\n/)) {
       const kv = line.match(/^(\w[\w-]*):\s*(.*)$/);
       if (kv) {
         let v = kv[2].trim();


### PR DESCRIPTION
Fixes #189.

`parseSkill` (used by `run` and `chain`) was still LF-only, so a SKILL.md authored on Windows fell through to `text.trim()` and pushed the raw `---` frontmatter into the system prompt. Aligned the regex with the other CRLF-tolerant parsers in the repo.

**Test**

```js
import { parseSkill } from './bin/lib/anthropic.mjs';
const crlf = '---\r\nname: crlf-test\r\ndescription: "Test"\r\n---\r\n\r\n# Body\r\n';
parseSkill(crlf);
// Before: { meta: {}, body: '---\r\nname: ...' }
// After:  { meta: { name: 'crlf-test', description: 'Test' }, body: '# Body' }
```