### PR TITLE
fix(ci): stop the feedback + trending crons failing on GoatCounter API errors

### DIFF
--- a/scripts/build-feedback.mjs
+++ b/scripts/build-feedback.mjs
@@ -27,12 +27,28 @@ const start = hour(new Date(Date.now() - 90 * 864e5));
 const end = hour(new Date());
 const url = `https://${SITE}.goatcounter.com/api/v0/stats/hits?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}&limit=200`;
 
-const res = await fetch(url, { headers: { authorization: 'Bearer ' + TOKEN } });
-if (!res.ok) {
-  console.error(`GoatCounter API ${res.status} for ${url}\n${(await res.text()).slice(0, 300)}`);
-  process.exit(1);
+// Best-effort refresh: GoatCounter being down, rate-limiting, or changing the
+// endpoint must NOT break CI — this is a proof-badge refresh, not a build gate.
+// On any non-OK or non-JSON response we warn and leave web/feedback.json as-is,
+// exactly like the no-token path above.
+let res;
+try {
+  res = await fetch(url, { headers: { authorization: 'Bearer ' + TOKEN } });
+} catch (e) {
+  console.warn(`GoatCounter fetch failed (${e.message}) — leaving web/feedback.json unchanged.`);
+  process.exit(0);
 }
-const data = await res.json();
+if (!res.ok) {
+  console.warn(`GoatCounter API ${res.status} for ${url} — leaving web/feedback.json unchanged.\n${(await res.text()).slice(0, 200)}`);
+  process.exit(0);
+}
+let data;
+try {
+  data = await res.json();
+} catch (e) {
+  console.warn(`GoatCounter returned non-JSON (${e.message}) — leaving web/feedback.json unchanged.`);
+  process.exit(0);
+}
 const allHits = data.hits || [];
 const num = (c) => Array.isArray(c) ? (c[0] || 0) : (typeof c === 'number' ? c : 0);
 const count = (h) => num(h.count) || (h.stats || []).reduce((a, s) => a + (s.daily || s.count || 0), 0) || 0;

--- a/scripts/build-trending.mjs
+++ b/scripts/build-trending.mjs
@@ -25,12 +25,27 @@ const start = hour(new Date(Date.now() - 7 * 864e5));
 const end = hour(new Date());
 const url = `https://${SITE}.goatcounter.com/api/v0/stats/hits?start=${encodeURIComponent(start)}&end=${encodeURIComponent(end)}&limit=200`;
 
-const res = await fetch(url, { headers: { authorization: 'Bearer ' + TOKEN } });
-if (!res.ok) {
-  console.error(`GoatCounter API ${res.status} for ${url}\n${(await res.text()).slice(0, 300)}`);
-  process.exit(1);
+// Best-effort refresh: a GoatCounter outage, rate-limit, or endpoint change must
+// NOT break CI. On any non-OK or non-JSON response we warn and leave the output
+// unchanged, exactly like the no-token path above.
+let res;
+try {
+  res = await fetch(url, { headers: { authorization: 'Bearer ' + TOKEN } });
+} catch (e) {
+  console.warn(`GoatCounter fetch failed (${e.message}) — leaving the trending data unchanged.`);
+  process.exit(0);
 }
-const data = await res.json();
+if (!res.ok) {
+  console.warn(`GoatCounter API ${res.status} for ${url} — leaving the trending data unchanged.\n${(await res.text()).slice(0, 200)}`);
+  process.exit(0);
+}
+let data;
+try {
+  data = await res.json();
+} catch (e) {
+  console.warn(`GoatCounter returned non-JSON (${e.message}) — leaving the trending data unchanged.`);
+  process.exit(0);
+}
 const allHits = data.hits || [];
 console.error(`GoatCounter: ${allHits.length} paths, ${allHits.filter((h) => h.event).length} events, ${allHits.filter((h) => /^\/?run\//.test(h.path || '')).length} run/ events in the window.`);
 // Our run events are recorded as path "run/<skill>" (event:true). A leading slash may be added.


### PR DESCRIPTION
## What does this PR add or change?

Makes the **Refresh feedback ratings** (and the sibling **trending**) cron jobs stop failing when GoatCounter's API errors. They've been red weekly for a month (feedback runs #4–#7).

## Root cause

`scripts/build-feedback.mjs` and `scripts/build-trending.mjs` both call GoatCounter's `GET /api/v0/stats/hits`, and on **any** non-200 they `process.exit(1)` — turning a best-effort proof-badge refresh into a build-breaking gate.

That endpoint now returns **404 with a valid token** (confirmed in the run #7 logs: `GoatCounter API 404 … <GoatCounter – Error!>`). The jobs last succeeded on 2026-06-23, so GoatCounter changed/removed `/api/v0/stats/hits` on their side around late June — nothing in this repo regressed.

## The fix

Both scripts now **degrade gracefully** — on a fetch error, a non-OK status, or a non-JSON body, they **warn and leave the committed JSON unchanged, exiting 0** — exactly like the existing `no GOATCOUNTER_TOKEN → no-op` path. A third-party analytics outage or endpoint change should never break the build.

- CI goes green.
- The committed `web/feedback.json` / trending data is preserved (nothing shown that isn't real).
- The commit step in the workflow finds no changes and no-ops cleanly.

## Testing

- `node --check` on both scripts.
- Ran `build-feedback.mjs` against the live API with a bad token (forces the error path): it now prints a warning and **exits 0** (was exit 1), and `web/feedback.json` is untouched.
- Swept `scripts/` for any other GoatCounter caller that still `exit(1)`s — none remain.

## Follow-up (out of scope here)

This restores green CI and preserves data, but new ratings won't *flow* until the fetch is re-pointed at GoatCounter's current stats endpoint (their `/api/v0/stats/hits` is gone). I didn't blind-guess a replacement — happy to wire the correct endpoint if you confirm it from GoatCounter's current API docs (or want me to test against the real token via a secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_