### PR TITLE
feat: house prose rules (3 tiers) + harden notes-humanizer against faked humanity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+Guidance for AI agents working in this repository. (Human contributors: see [CONTRIBUTING.md](CONTRIBUTING.md) and [SKILL-AUTHORING-STANDARD.md](SKILL-AUTHORING-STANDARD.md).)
+
+## What this repo is
+
+A library of professional **Agent Skills** — each a plain `SKILL.md` file that teaches an assistant to do one professional task well. Skills live in `skills/<name>/SKILL.md`; bundles in `plugins/<bundle>/`; the marketplace in `.claude-plugin/marketplace.json`.
+
+## Working conventions
+
+- **New skill / bundle:** scaffold with `node scripts/new-skill.mjs` or `node scripts/new-bundle.mjs` — don't hand-wire `plugins/` and `marketplace.json`.
+- **Every skill must pass the L3 / SkillSpec gate.** Validate with `node scripts/skillcheck.mjs`.
+- **Keep counts honest.** After adding skills, run `node scripts/check-drift.mjs` (skill/bundle counts across docs must match) and regenerate derived files with `npm run check`.
+- **Don't hand-edit generated files** (`web/skills.json`, `exports/**`, `web/catalog.html`, `web/coverage.html`) — they're rebuilt.
+- **Ship via a branch + PR**, not direct pushes to `main`.
+
+## House prose rules (the mini standard)
+
+Everything you write — skill bodies, docs, and the prose a skill *produces* — follows this. Full version: [`docs/prose-style.md`](docs/prose-style.md); as a persona: [`output-styles/plain-honest-prose.md`](output-styles/plain-honest-prose.md).
+
+- Write for a specific reader and the action the text is for.
+- Match voice to genre: docs and summaries stay neutral; only personal/persuasive writing shows a person. When unsure, neutral.
+- Give every paragraph a checkable detail — but **never invent a number, quote, date, or fact to sound specific.** Hedge honestly or ask.
+- Plain words over inflated ones; drop filler (*leverage, robust, seamless, delve, game-changer*).
+- Cut the staged parts: no ceremonial openers ("Let's dive in", "It's worth noting"), no keynote rule-of-three, no "Great question!", no "In conclusion" restatement.
+- Don't fake humanity: no manufactured typos, forced slang, random "But" openers, or sentences chopped just to vary length. Earned, or absent.
+- Keep useful structure (headings, steps, tables); remove decoration, not architecture.
+- Revise by reading and cutting — it should end shorter than it started.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
 
 ## [Unreleased]
 
+### Added — ✍️ house prose rules (three tiers)
+- **[docs/prose-style.md](docs/prose-style.md)** — the full writing standard for prose the library *produces* and the prose in its own skills/docs: write for the job, calibrate voice to genre, concrete anchors, **never invent specificity**, ordinary words, cut the staged parts, don't fake humanity, keep useful structure, revise by cutting.
+- **[output-styles/plain-honest-prose.md](output-styles/plain-honest-prose.md)** — the same rules as a Claude Code output-style persona (applies the house voice to any skill's output).
+- **[AGENTS.md](AGENTS.md)** — a root agent-guidance file (new) carrying the mini prose ruleset + repo working conventions.
+
+### Changed — 🧽 notes-humanizer hardened
+- Added a **genre-calibration gate** (Phase 0): neutral docs/summaries get tells stripped and *nothing injected*; only personal/persuasive text gets earned voice.
+- Reframed the "inject" moves from mandatory quotas to **earned-or-absent**, and added explicit guardrails: **no faked humanity** (no manufactured typos/slang/length-variance/staged messiness) and **no invented specificity** (never fabricate a number, quote, or fact to sound concrete).
+
 ## [61.1.0] — the demand side: find the right skill, trust the badge, adopt the spec — 2026-07-21
 
 Four systems that turn a 750-skill factory into something a person can actually navigate and trust. **750 skills, 90 bundles** — no new wave, all depth.

--- a/docs/prose-style.md
+++ b/docs/prose-style.md
@@ -1,0 +1,74 @@
+# House Prose Rules
+
+The writing standard for output produced by this library — the prose that comes *out* of a skill, and the prose in the skills, docs, and READMEs themselves. The goal is plain: text that reads like a competent professional wrote it on purpose, not like a model filled a template. Sharper, more concrete, less generic — without cheap tricks.
+
+This is the **full** version. Two shorter forms carry the same rules for different budgets:
+- **Compact** — the [`plain-honest-prose`](../output-styles/plain-honest-prose.md) output-style, a persona that applies these rules to any skill's output (switch with `/output-style` in Claude Code).
+- **Mini** — the ~15-line block in the repo's root [`AGENTS.md`](../AGENTS.md), for agents that read it automatically.
+
+> Related skills, when you want a tool rather than a rule: [`notes-humanizer`](../skills/notes-humanizer/SKILL.md) (strip AI tells from one draft), [`house-style-enforcer`](../skills/house-style-enforcer/SKILL.md) (enforce a *team's* exemplar style), [`plain-language-rewrite`](../skills/plain-language-rewrite/SKILL.md) (de-jargon), [`ai-content-audit`](../skills/ai-content-audit/SKILL.md) (audit a whole library for slop).
+
+---
+
+## 1. Start from the job of the text
+
+Before the first sentence, know three things: the **medium**, the **reader**, and the **decision or action** the text exists to produce. A board update, a runbook, a cold email, and a blog post are four different jobs with four different shapes. Most generic writing is generic because it was written for no one in particular.
+
+## 2. Calibrate voice to genre
+
+Voice is not a constant to maximise — it's a dial you set by genre.
+- **Neutral / informational** (docs, references, summaries, reports, official comms): no personality. Clear, scannable, correct. Injected "voice" here reads as unprofessional.
+- **Personal / persuasive** (opinion, blog, founder notes, marketing, personal email): a real person can show through — a stated view, a concrete anecdote, a plain aside.
+- When unsure, go neutral. Under-flavoured beats over-flavoured.
+
+## 3. Concrete anchors over polished generality
+
+If a paragraph contains no checkable detail — a number, a name, an example, a mechanism — it is probably filler, however smooth it reads. Revise it or cut it. "Drives significant efficiency gains" says nothing; "cuts the weekly close from three days to one" says something. Prefer the sentence a reader could argue with.
+
+## 4. Never fake specificity
+
+The one line that outranks all others: **do not invent detail to sound concrete.** No fabricated numbers, quotes, dates, names, study citations, or causal claims. A made-up statistic is worse than an honest "we haven't measured this yet." If a claim needs support it doesn't have, hedge it honestly or ask for the source — never manufacture one. Concreteness is only a virtue when it's true.
+
+## 5. Ordinary words
+
+Prefer the plain word to the inflated one: *use* over *utilise*, *help* over *facilitate*, *about* over *in the region of*. Kill the thesaurus reach. Repetition of the right ordinary word beats variation for its own sake — you don't need three synonyms for "customer." Drop the words that only signal effort: *leverage, robust, seamless, holistic, myriad, delve, navigate* (used for non-navigation), *game-changer, best-in-class*.
+
+## 6. Cut the staged parts
+
+Model prose stages a performance. Remove the theatre:
+- **Ceremonial openings** — "In today's fast-paced world…", "Let's dive in", "It's worth noting that". Start with the actual first point.
+- **Keynote cadence** — the rising rule-of-three, the portentous one-line paragraph, the rhetorical question you immediately answer.
+- **Service-desk tone** — "Great question!", "I'd be happy to help you with that." Just do the thing.
+- **Filler closings** — "In conclusion", "At the end of the day", the summary that restates what was just said. End on the last real point.
+
+## 7. Break the templated shape
+
+Even with clean words, prose can still *look* generated: every paragraph the same length, every section a bulleted list, every list item the same grammar and word count, signposts ("Firstly… Moreover… Furthermore…") standing in for actual transitions. Vary the shape where the meaning varies — but only where it varies (see §8).
+
+## 8. Don't fake humanity
+
+The failure mode of "make it sound human": inventing the signals mechanically. **No manufactured typos, no forced slang, no random "But" to open a sentence, no chopping a sentence to a stub just to vary length, no staged messiness.** A signal inserted to hit a quota is itself a tell. Let a sentence be short when the point lands short; start with "And" only where the rhythm truly earns it; add an aside only when there's a real one to add. Earned, or absent.
+
+## 9. Keep the structure that helps
+
+Scannability is not slop. A doc that needs headings, a procedure that needs numbered steps, a comparison that needs a table — keep them. Don't dissolve genuine structure into prose just to look less templated. Remove decoration, not architecture.
+
+## 10. Revise by reading and cutting
+
+The edit that does most of the work: read it back and delete. Collapse restatements into one line. Drop the "announcement" sentences that say what the next sentence will say ("Now let's look at the three main benefits."). Replace the single most generic clause with something specific. Cut every word that isn't carrying weight. Prose gets better mostly by getting shorter.
+
+---
+
+## The two-minute checklist
+
+- [ ] I could name the reader and the action this text is for.
+- [ ] Voice matches the genre (neutral stays neutral).
+- [ ] Every paragraph has at least one checkable, **true** detail.
+- [ ] Nothing was invented to sound specific.
+- [ ] Plain words; no thesaurus reach; no effort-signalling adjectives.
+- [ ] No ceremonial opener, keynote cadence, service-desk tone, or filler close.
+- [ ] Shape varies with meaning, not on a schedule; no faked "human" signals.
+- [ ] Useful structure kept; decoration cut.
+- [ ] Read back and cut — it's shorter than the first draft.
+
+*This document is original to this repository (MIT). The approach is informed by widely-shared writing principles; the wording here is our own.*

--- a/exports/aider/pm-writers/notes-humanizer/notes-humanizer.md
+++ b/exports/aider/pm-writers/notes-humanizer/notes-humanizer.md
@@ -59,8 +59,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -83,6 +83,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -108,19 +118,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -136,20 +146,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/chatgpt/pm-writers/notes-humanizer/SYSTEM_PROMPT.md
+++ b/exports/chatgpt/pm-writers/notes-humanizer/SYSTEM_PROMPT.md
@@ -59,8 +59,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -83,6 +83,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -108,19 +118,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -136,20 +146,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/cline/pm-writers/notes-humanizer/notes-humanizer.md
+++ b/exports/cline/pm-writers/notes-humanizer/notes-humanizer.md
@@ -59,8 +59,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -83,6 +83,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -108,19 +118,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -136,20 +146,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/continue/pm-writers/notes-humanizer/notes-humanizer.md
+++ b/exports/continue/pm-writers/notes-humanizer/notes-humanizer.md
@@ -1,6 +1,6 @@
 ---
 name: "Strips AI writing patterns from text and rewrites it to soun"
-description: "Strips AI writing patterns from text and rewrites it to sound genuinely human by removing statistical defaults and injecting the specific signals that human writers produce. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
+description: "Strips AI writing patterns from text and rewrites it to sound genuinely human — removing the statistical defaults, then adding earned voice calibrated to genre (opinion pieces get a person's voice; docs and summaries stay neutral) without ever faking humanity. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
 ---
 
 # Notes Humanizer
@@ -64,8 +64,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -88,6 +88,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -113,19 +123,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -141,20 +151,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/cursor/pm-writers/notes-humanizer/notes-humanizer.mdc
+++ b/exports/cursor/pm-writers/notes-humanizer/notes-humanizer.mdc
@@ -1,5 +1,5 @@
 ---
-description: "Strips AI writing patterns from text and rewrites it to sound genuinely human by removing statistical defaults and injecting the specific signals that human writers produce. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
+description: "Strips AI writing patterns from text and rewrites it to sound genuinely human — removing the statistical defaults, then adding earned voice calibrated to genre (opinion pieces get a person's voice; docs and summaries stay neutral) without ever faking humanity. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
 globs:
 alwaysApply: false
 ---
@@ -65,8 +65,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -89,6 +89,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -114,19 +124,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -142,20 +152,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/gemini/pm-writers/notes-humanizer/GEM_INSTRUCTIONS.md
+++ b/exports/gemini/pm-writers/notes-humanizer/GEM_INSTRUCTIONS.md
@@ -1,4 +1,4 @@
-You are a specialised assistant. Strips AI writing patterns from text and rewrites it to sound genuinely human by removing statistical defaults and injecting the specific signals that human writers produce. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste.
+You are a specialised assistant. Strips AI writing patterns from text and rewrites it to sound genuinely human — removing the statistical defaults, then adding earned voice calibrated to genre (opinion pieces get a person's voice; docs and summaries stay neutral) without ever faking humanity. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste.
 
 Follow these instructions:
 
@@ -63,8 +63,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -87,6 +87,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -112,19 +122,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -140,20 +150,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/kilocode/pm-writers/notes-humanizer/notes-humanizer.md
+++ b/exports/kilocode/pm-writers/notes-humanizer/notes-humanizer.md
@@ -59,8 +59,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -83,6 +83,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -108,19 +118,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -136,20 +146,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/obsidian/pm-writers/notes-humanizer/notes-humanizer.md
+++ b/exports/obsidian/pm-writers/notes-humanizer/notes-humanizer.md
@@ -2,7 +2,7 @@
 aliases: ["Notes Humanizer"]
 tags: [pm-skills, skill]
 skill: notes-humanizer
-description: "Strips AI writing patterns from text and rewrites it to sound genuinely human by removing statistical defaults and injecting the specific signals that human writers produce. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
+description: "Strips AI writing patterns from text and rewrites it to sound genuinely human — removing the statistical defaults, then adding earned voice calibrated to genre (opinion pieces get a person's voice; docs and summaries stay neutral) without ever faking humanity. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
 ---
 
 # Notes Humanizer
@@ -66,8 +66,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -90,6 +90,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -115,19 +125,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -143,20 +153,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/openclaw/notes-humanizer/SKILL.md
+++ b/exports/openclaw/notes-humanizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notes-humanizer
-description: "Strips AI writing patterns from text and rewrites it to sound genuinely human by removing statistical defaults and injecting the specific signals that human writers produce. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
+description: "Strips AI writing patterns from text and rewrites it to sound genuinely human — removing the statistical defaults, then adding earned voice calibrated to genre (opinion pieces get a person's voice; docs and summaries stay neutral) without ever faking humanity. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
 homepage: https://mohitagw15856.github.io/pm-claude-skills/skill/notes-humanizer.html
 metadata:
   {
@@ -69,8 +69,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -93,6 +93,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -118,19 +128,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -146,20 +156,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/roo/pm-writers/notes-humanizer/notes-humanizer.md
+++ b/exports/roo/pm-writers/notes-humanizer/notes-humanizer.md
@@ -59,8 +59,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -83,6 +83,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -108,19 +118,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -136,20 +146,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/windsurf/pm-writers/notes-humanizer/notes-humanizer.md
+++ b/exports/windsurf/pm-writers/notes-humanizer/notes-humanizer.md
@@ -1,6 +1,6 @@
 ---
 trigger: model_decision
-description: "Strips AI writing patterns from text and rewrites it to sound genuinely human by removing statistical defaults and injecting the specific signals that human writers produce. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
+description: "Strips AI writing patterns from text and rewrites it to sound genuinely human — removing the statistical defaults, then adding earned voice calibrated to genre (opinion pieces get a person's voice; docs and summaries stay neutral) without ever faking humanity. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
 ---
 
 # Notes Humanizer
@@ -64,8 +64,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -88,6 +88,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -113,19 +123,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -141,20 +151,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/exports/zed/pm-writers/notes-humanizer/notes-humanizer.md
+++ b/exports/zed/pm-writers/notes-humanizer/notes-humanizer.md
@@ -59,8 +59,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -83,6 +83,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -108,19 +118,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -136,20 +146,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration

--- a/output-styles/README.md
+++ b/output-styles/README.md
@@ -9,6 +9,7 @@ loadout. Switch with `/output-style` in Claude Code, or install them with the sk
 | `Growth Marketer` | Funnel & experiment driven | positioning, GTM, content, A/B tests |
 | `Solo Founder` | Ruthless prioritisation, leverage | prioritisation, positioning, ops |
 | `Product Leader` | Outcome-oriented, crisp comms | PRDs, OKRs, roadmap, stakeholder comms |
+| `Plain & Honest Prose` | Plain, concrete, no AI tells, no faked specificity | any writing task — the house prose voice ([`docs/prose-style.md`](../docs/prose-style.md)) |
 
 ## Install
 

--- a/output-styles/plain-honest-prose.md
+++ b/output-styles/plain-honest-prose.md
@@ -1,0 +1,18 @@
+---
+name: Plain & Honest Prose
+description: House writing voice — plain, concrete, and honest. Strips the AI tells (ceremonial openers, keynote cadence, filler closings) and never invents specificity, while keeping useful structure and matching voice to genre.
+---
+
+You write like a competent professional writing on purpose — not like a model filling a template. Apply this to everything you produce.
+
+- **Write for the job.** Know the reader and the action the text is for before the first sentence.
+- **Match voice to genre.** Docs, summaries, and reports stay neutral — no injected personality. Opinion, blog, and personal writing can show a real person. When unsure, go neutral.
+- **Concrete over polished.** Every paragraph needs at least one checkable detail — a number, name, example, or mechanism. If a paragraph has none, revise or cut it.
+- **Never fake specificity.** Do not invent numbers, quotes, dates, names, citations, or causal claims to sound concrete. Hedge honestly or ask for the source instead. A made-up figure is worse than "we haven't measured this."
+- **Ordinary words.** Plain over inflated (*use* not *utilise*). Drop effort-signalling filler: leverage, robust, seamless, holistic, delve, game-changer. Repeating the right plain word beats thesaurus variety.
+- **Cut the staged parts.** No ceremonial openers ("In today's world", "Let's dive in", "It's worth noting"), no keynote rule-of-three cadence, no "Great question!", no "In conclusion" restatement. Start on the point; end on the last real one.
+- **Don't fake humanity.** No manufactured typos, forced slang, random "But" openers, stub sentences chopped for "variance," or staged messiness. Let brevity and asides appear only where the content earns them — otherwise leave them out.
+- **Keep structure that helps.** Headings, numbered steps, and tables earn their place; don't dissolve them into prose just to look less templated. Remove decoration, not architecture.
+- **Revise by cutting.** Read it back, collapse restatements, drop announcement sentences, and delete every word not carrying weight. It should end shorter than it started.
+
+Full standard: `docs/prose-style.md`. When the user wants a tool rather than a default voice, reach for `notes-humanizer` (fix one draft) or `house-style-enforcer` (match a team's style).

--- a/skills/notes-humanizer/SKILL.md
+++ b/skills/notes-humanizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: notes-humanizer
-description: "Strips AI writing patterns from text and rewrites it to sound genuinely human by removing statistical defaults and injecting the specific signals that human writers produce. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
+description: "Strips AI writing patterns from text and rewrites it to sound genuinely human — removing the statistical defaults, then adding earned voice calibrated to genre (opinion pieces get a person's voice; docs and summaries stay neutral) without ever faking humanity. Use when a draft reads as AI-generated, over-polished, or rhythmically uniform — including blog posts, emails, LinkedIn posts, or any prose that needs to sound like a real person wrote it. Produces a pattern audit, side-by-side comparison, itemised change log, and clean rewritten output ready to paste."
 ---
 
 # Notes Humanizer
@@ -64,8 +64,8 @@ CHANGES MADE
    → "X and Y. Z is different — [expanded thought]"
    Why: all three items had identical rhythm; broke the pattern
 
-4. Added short sentence: "That's the problem."
-   Why: needed a sub-8-word sentence to vary rhythm
+4. Split a 30-word sentence where the point turned: "…and it failed. That's the problem."
+   Why: the meaning lands on a short beat here — the brevity is earned, not inserted for variance
 
 5. Added sentence starting with "But"
    Why: human writers do this; AI avoids it as a statistical default
@@ -88,6 +88,16 @@ The full rewritten text, ready to copy and paste — no annotations, no formatti
 ---
 
 ## Instructions for Claude
+
+### Phase 0: Calibrate to genre (do this first)
+
+Before touching anything, decide what kind of text this is — the genre sets how far Phase 2 goes:
+
+- **Neutral / informational** (documentation, reference, summaries, status reports, official notices, most business comms): run **Phase 1 only**. Strip the tells and stop. Do **not** inject opinion, asides, or personality — a clean doc is the goal, not a voice. Injected "humanity" here reads as unprofessional.
+- **Personal / persuasive / social** (opinion pieces, blog posts, founder notes, LinkedIn, marketing, personal emails): run **Phase 1 + Phase 2**. Here earned voice is the point.
+- **Unsure or mixed:** default to the lighter touch (Phase 1, plus only the Phase 2 moves the content genuinely earns), and say which genre you assumed.
+
+The single rule underneath: **calibrate voice to the job of the text.** Never dismantle useful structure (a scannable doc, a real list) just to look less templated.
 
 ### Phase 1: Audit
 
@@ -113,19 +123,19 @@ Read the full text before making any changes. Identify and count every instance 
 
 Do not remove every em dash — only the ones used as parenthetical substitutes. Do not remove all hedging — only empty hedging that adds no information.
 
-### Phase 2: Inject
+### Phase 2: Inject (personal / persuasive genres only — see Phase 0)
 
-After stripping patterns, add the following signals. Each one should emerge from the actual content — don't add generic filler:
+Only for text where earned voice is the point. These are **options the content earns, not a checklist to complete** — apply the ones the material genuinely supports and **skip any that would be forced**. A move inserted to hit a quota is itself an AI tell. Never fake humanity: no invented typos, no forced slang, no staged messiness, and no chopping or padding sentences just to manufacture rhythm variance.
 
-1. **One genuine opinion or take.** The author appears to actually believe something specific. State it without hedging. ("This approach works, and I think most people underestimate how rarely the alternative does.")
+1. **A genuine opinion or take** *(if the author clearly holds one).* State the belief the text already implies, without hedging. Don't manufacture an opinion the author never expressed.
 
-2. **One specific detail, example, or number.** Ground the most abstract claim in the text with something concrete. If the text says "this happens frequently," add a real or illustrative number. If it says "many companies do this," name the type of company.
+2. **A specific detail or example** *(only if a real one exists).* Ground the most abstract claim in something concrete the author actually knows. **Never invent a number, quote, date, name, or fact to sound specific** — that's fake specificity, a worse tell than vagueness. If no real detail is available, ask the author for one or keep the honest abstraction; do not fabricate.
 
-3. **One aside or parenthetical thought that breaks the fourth wall slightly.** This is the signal most synthetic text lacks — the writer momentarily steps out of the formal argument to say something human. ("(I've seen this specific mistake made by people who absolutely should have known better.)")
+3. **An aside that steps out of the formal argument** *(where it fits the register).* The signal most synthetic text lacks — but only in genres that welcome it, and only when it connects to a real point. Forced or cutesy asides are worse than none.
 
-4. **At least one sentence under 8 words.** Make it land on a point, not a transition.
+4. **Let a sentence be short where the point lands on a short beat.** Follow the meaning, not a word count. Never shorten a sentence just to add "variance."
 
-5. **One sentence that starts with "And" or "But."** Place it where the rhythm earns it, not randomly.
+5. **Start a sentence with "And" or "But" only where the rhythm truly earns it.** If no place does, don't add one — a random "But" is a tell, not a fix.
 
 ### Phase 3: Report
 
@@ -141,20 +151,25 @@ Present the output in the four-section structure defined above. The change log m
 
 ## Quality Checks
 
+- [ ] Genre was assessed first (Phase 0); neutral/informational text got Phase 1 only, with no injected opinion, aside, or personality
 - [ ] Audit was completed before rewriting (patterns counted, not just detected)
 - [ ] Every removed pattern is listed in the change log with a specific reason
 - [ ] Em dashes were assessed individually — only parenthetical-substitute uses were removed
 - [ ] Rule-of-three lists: the rhythm was actually checked, not just the fact that there were three items
-- [ ] At least one sentence under 8 words was added (or was already present)
-- [ ] At least one sentence starts with "And" or "But" in the final text
+- [ ] No fact, number, quote, date, or name was invented to add specificity
+- [ ] Any Phase 2 moves applied were earned by the content — none inserted to hit a quota (short sentence / "And"/"But" opener / aside added only where the material genuinely called for it, or not at all)
 - [ ] The specific detail or example added connects to an actual claim in the text, not floated in generically
-- [ ] The aside breaks the fourth wall slightly without being forced or cutesy
+- [ ] The aside (if any) breaks the fourth wall slightly without being forced or cutesy
 - [ ] The change log lists specific instances, not categories
 - [ ] The clean output section has no annotations or formatting artifacts — ready to paste
 - [ ] If the original was already clean, that was stated explicitly rather than changes invented
 
 ## Anti-Patterns
 
+- [ ] Do not fake humanity: no invented typos, no forced slang, no staged messiness, and no programmatic sentence-length variation added to hit a target — faked signals are themselves AI tells
+- [ ] Do not inject voice into neutral genres — documentation, summaries, reports, and official comms get the tells stripped and nothing added; personality there reads as unprofessional
+- [ ] Do not invent specificity — never add a number, quote, date, name, or fact that isn't real to make prose sound concrete; ask for the detail or keep the honest abstraction
+- [ ] Do not dismantle useful structure (a scannable layout, a genuine list) just to look less templated
 - [ ] Do not remove all em dashes — only the ones functioning as parenthetical substitutes should be removed; genuine dramatic pauses are valid
 - [ ] Do not invent problems to justify changes when the original is already clean — report what was found honestly, even if the answer is "this text is mostly fine"
 - [ ] Do not add the aside or opinion generically — the injected human signals must connect to an actual claim or argument in the text, not float in as decoration


### PR DESCRIPTION
## What does this PR add or change?

Two things learned from the [WRITING.md project](https://github.com/Anbeeld/WRITING.md), adapted to this repo — **without duplicating what we already have** (`notes-humanizer`, `house-style-enforcer`, `ai-content-audit`) and **in our own words** (that repo states no licence, so this borrows principles, not text).

## 1. A repo-level house prose standard, in three tiers

We had skills and personas but **no always-on writing standard** and no `AGENTS.md`. Now:

- **Full** — [`docs/prose-style.md`](docs/prose-style.md): write for the job; calibrate voice to genre (neutral docs stay neutral); concrete anchors; **never invent specificity**; ordinary words; cut the staged parts (ceremonial openers, keynote cadence, service-desk tone, filler closings); don't fake humanity; keep useful structure; revise by cutting. Ends with a two-minute checklist.
- **Compact** — [`output-styles/plain-honest-prose.md`](output-styles/plain-honest-prose.md): the same rules as a Claude Code **output-style persona**, so the house voice applies to *any* skill's output (`/output-style`). Added to the personas table.
- **Mini** — [`AGENTS.md`](AGENTS.md) (new root file): the ~15-line ruleset plus real repo working conventions, for agents that auto-read it.

This improves the whole library's *output by default*, and complements `house-style-enforcer` (which enforces a **team's** exemplar style) rather than duplicating it.

## 2. Harden `notes-humanizer` (a real gap it had)

The skill used to **inject humanity by quota, regardless of genre** — its Phase 2 *required* a sub-8-word sentence, an "And/But" opener, and a fourth-wall aside on every text. That's exactly the "programmatic sentence-length variation / staged messiness" that reads as an AI tell, and it would put personality into a neutral doc.

Changes:
- **Phase 0 genre gate** — neutral/informational text (docs, summaries, reports, official comms) gets the tells stripped and **nothing injected**; only personal/persuasive text gets earned voice.
- Reframed the inject moves from mandatory quotas to **earned-or-absent** ("a signal inserted to hit a quota is itself a tell").
- New guardrails: **no faked humanity** (no manufactured typos/slang/length-variance/staged messiness) and **no invented specificity** (never fabricate a number, quote, date, or fact to sound concrete).
- Updated the description, Quality Checks, Anti-Patterns, and the one change-log example that taught the old quota behaviour.

## Testing

- `skillcheck`: **750 skills, 0 errors** — `notes-humanizer` still L3-conformant.
- `check-drift`: clean on tracked files (only the git-ignored generated `catalog/coverage.html` remain).
- No skill/bundle count change, so no release-field bump; noted under CHANGELOG `[Unreleased]`.

## Note

Everything here is original wording; the WRITING.md repo is credited in the commit as the source of the *approach* only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_