### PR TITLE
release: v61.2.0 — the builder's toolkit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "pm-claude-skills",
-  "version": "61.1.0",
+  "version": "61.2.0",
   "description": "PM stands for Professional, not just Product Management. 515 Claude Skills + 4 agent templates across 74 bundles covering 31 professions \u2014 engineering, security, AI/ML, customer success, legal, government & policy, finance, personal finance, HR, sales, design, Figma, marketing, social media, writers, developer relations, founders/startups, healthcare, nonprofit, crisis comms, educators, content creators, and more. Built by a PM, used by everyone. Building blocks for the Anthropic agent template architecture.",
   "owner": {
     "name": "Mohit Aggarwal",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
 
 ## [Unreleased]
 
+## [61.2.0] — the builder's toolkit: prove it, harden it, run it your way — 2026-07-22
+
+No new skills — this release is about the *infrastructure* around the 750: proving quality against real references, red-teaming robustness, testing skills before a PR, running them offline, signing what they produce, and a house prose standard the whole library writes to. **750 skills, 92 bundles.**
+
 ### Added — 🧰 ten builder/quality/trust tools
 
 Quality & proof:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-claude-skills",
-  "version": "61.1.0",
+  "version": "61.2.0",
   "type": "module",
   "mcpName": "io.github.mohitagw15856/pm-claude-skills",
   "description": "750 professional Agent Skills (SKILL.md) + subagents + slash commands for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes. It's a CLI, not a library: run `npx pm-claude-skills add --agent <tool>` to install into your AI tool — no `npm install` needed. Or try any skill free at https://mohitagw15856.github.io/pm-claude-skills/",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/mohitagw15856/pm-claude-skills",
     "source": "github"
   },
-  "version": "61.1.0",
+  "version": "61.2.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "pm-claude-skills",
-      "version": "61.1.0",
+      "version": "61.2.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What does this PR add or change?

Cuts **v61.2.0**. Bumps the four release fields (package.json, marketplace.json, server.json ×2) to `61.2.0` and finalises the CHANGELOG `[61.2.0]` entry, rolling up everything currently under `[Unreleased]`:

- the **ten builder/quality/trust tools** (#200)
- the **three-tier house prose rules** (#199)
- the **notes-humanizer** hardening (#199)

**No new skills** — this is infrastructure, so a minor bump per the repo convention. **750 skills · 92 bundles.**

## Testing
- All four version fields verified at `61.2.0`; JSON valid.
- `check-drift`: clean on tracked files (only the git-ignored generated `catalog/coverage.html` remain).
- No skill/generated-file changes → the export & skills.json CI gates aren't in play.

## After merge
Create the GitHub Release + tag **`v61.2.0`** (notes provided separately) to fire npm-publish, the MCP registry, and the ClawHub sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_