### PR TITLE
release: v61.2.1 — re-cut of 61.2.0 (immutable-tag lock)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "pm-claude-skills",
-  "version": "61.2.0",
+  "version": "61.2.1",
   "description": "PM stands for Professional, not just Product Management. 515 Claude Skills + 4 agent templates across 74 bundles covering 31 professions \u2014 engineering, security, AI/ML, customer success, legal, government & policy, finance, personal finance, HR, sales, design, Figma, marketing, social media, writers, developer relations, founders/startups, healthcare, nonprofit, crisis comms, educators, content creators, and more. Built by a PM, used by everyone. Building blocks for the Anthropic agent template architecture.",
   "owner": {
     "name": "Mohit Aggarwal",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ each new wave of skills bumps the **major** version, extensions and fixes bump
 
 ## [Unreleased]
 
-## [61.2.0] — the builder's toolkit: prove it, harden it, run it your way — 2026-07-22
+## [61.2.1] — the builder's toolkit: prove it, harden it, run it your way — 2026-07-22
+
+> _(61.2.0 was skipped: its release tag was cut before the version-bump merged, and GitHub's immutable-release lock prevented reusing the tag. Nothing published under 61.2.0 — this is the same release, re-cut cleanly.)_
 
 No new skills — this release is about the *infrastructure* around the 750: proving quality against real references, red-teaming robustness, testing skills before a PR, running them offline, signing what they produce, and a house prose standard the whole library writes to. **750 skills, 92 bundles.**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-claude-skills",
-  "version": "61.2.0",
+  "version": "61.2.1",
   "type": "module",
   "mcpName": "io.github.mohitagw15856/pm-claude-skills",
   "description": "750 professional Agent Skills (SKILL.md) + subagents + slash commands for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes. It's a CLI, not a library: run `npx pm-claude-skills add --agent <tool>` to install into your AI tool — no `npm install` needed. Or try any skill free at https://mohitagw15856.github.io/pm-claude-skills/",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/mohitagw15856/pm-claude-skills",
     "source": "github"
   },
-  "version": "61.2.0",
+  "version": "61.2.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "pm-claude-skills",
-      "version": "61.2.0",
+      "version": "61.2.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## What does this PR add or change?

Bumps the release to **61.2.1** so the release can actually be cut.

## Why

The `v61.2.0` tag was created against `main` *before* the version-bump merged, so the publish workflows failed the tag-vs-`package.json` guard. When we went to re-cut it, **GitHub's immutable-releases lock had already burned the `v61.2.0` tag** — it can't be reused. Nothing was published under 61.2.0 (both npm and MCP-registry publishes failed at the guard, before publishing). So we move to a clean patch version.

## Changes
- Four release fields (package.json, marketplace.json, server.json ×2) → **61.2.1**.
- CHANGELOG entry re-headed `[61.2.0]` → `[61.2.1]` with a one-line note explaining the skip. Same contents (the ten builder tools + house prose rules).

## Testing
- All four fields verified at `61.2.1`; JSON valid.
- `check-drift` clean on tracked files (only git-ignored generated `catalog/coverage.html`).

## After merge — the correct order this time
1. Merge this PR **first** (so `main` is 61.2.1).
2. **Then** create the GitHub Release + tag **`v61.2.1`** targeting `main`.

That order matters: the tag must point at a commit whose `package.json` is `61.2.1`, or the publish guard fails again. With this merged first, `v61.2.1` off `main` publishes clean to npm + the MCP registry (+ ClawHub sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_