### PR TITLE
release: bump PyPI pm-skills 0.21.0 → 0.22.0 (missed in the #202 squash)

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pm-skills"
-version = "0.21.0"
+version = "0.22.0"
 description = "206 professional Agent Skills (PRDs, launch plans, postmortems, rubrics, contracts…) as importable building blocks for Python AI agents — LangChain, CrewAI, LlamaIndex, or any framework."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## What does this PR add or change?

Bumps `python/pyproject.toml` (`pm-skills`) **0.21.0 → 0.22.0**.

## Why

The Python package versions **independently** (0.19 → 0.20 → 0.21 each release, not on the `61.x` line). The 61.2.1 release PR (#202) merged with only the four `61.x` fields — the Python bump commit didn't make it into the squash, so `main` still has `0.21.0`.

Without this, the release's PyPI publish (`skip-existing: true`) would **silently skip** — no failure, but PyPI never gets this release's refreshed catalog. This catches it up.

## ⚠️ Merge this BEFORE cutting the tag

`main` currently has: `package.json`/`marketplace.json`/`server.json` = **61.2.1**, but `pyproject.toml` = **0.21.0**. Merge this so `main` is fully release-ready (0.22.0), **then** create the Release + tag **`v61.2.1`** off `main`. Then npm (61.2.1) + MCP registry + PyPI (0.22.0) all publish cleanly.

*(If you've already cut `v61.2.1`, merge this and re-run the **Publish to PyPI** workflow manually — Actions → Run workflow — since only PyPI is affected; npm and the MCP registry are unaffected.)*

## Testing
- `pyproject.toml` version verified at `0.22.0`; no other files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_