### PR TITLE
docs(readme): fix banner to 832 + add a "See it in action" GIF showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ Works natively in **Claude Code** and **Hermes Agent**, with ready-to-paste expo
 
 **Don't know what to look for?** Describe your task in plain words at **[🔎 find](https://mohitagw15856.github.io/pm-claude-skills/find.html)** — *"my landlord kept my deposit"*, *"board meeting on Thursday"* — and it names the skill.
 
+## ✨ See it in action
+
+It's not just a folder of files — the whole library is explorable, runnable, and a little bit magic. All of this runs **in your browser, free, nothing to install:**
+
+<table>
+<tr>
+<td width="50%" align="center">
+<a href="https://mohitagw15856.github.io/pm-claude-skills/galaxy3d.html"><img src="web/docs-assets/demo-galaxy.gif" width="100%" alt="Galaxy 3D — fly through all 832 skills as a glowing constellation you orbit and click into" /></a>
+<br /><sub><b>🌌 <a href="https://mohitagw15856.github.io/pm-claude-skills/galaxy3d.html">Galaxy 3D</a></b> — fly through all 832 skills as a living constellation. The ones you've run burn brighter.</sub>
+</td>
+<td width="50%" align="center">
+<a href="https://mohitagw15856.github.io/pm-claude-skills/wrapped.html"><img src="web/docs-assets/demo-holo.gif" width="100%" alt="PM Skills Wrapped — your practice turned into a shareable, Spotify-Wrapped-style story" /></a>
+<br /><sub><b>🎁 <a href="https://mohitagw15856.github.io/pm-claude-skills/wrapped.html">Wrapped</a></b> — your practice, as a shareable story. 100% local — nothing leaves your browser.</sub>
+</td>
+</tr>
+</table>
+
+▶ **[Open the Playground](https://mohitagw15856.github.io/pm-claude-skills/)** to run any of the 832 skills with your own key — or just [browse them all](SKILLS.md).
+
 ## 💬 What can I ask it to do?
 
 Anything below is a real ask that activates a real skill — say it in your own words, the description does the routing:

--- a/web/docs-assets/hero.svg
+++ b/web/docs-assets/hero.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="320" viewBox="0 0 1200 320" role="img" aria-label="PM Skills — 822 professional agent skills your AI can read">
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="320" viewBox="0 0 1200 320" role="img" aria-label="PM Skills — 832 professional agent skills your AI can read">
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#1b1035"/>
@@ -37,7 +37,7 @@
   <!-- wordmark -->
   <text x="92" y="140" font-size="64" font-weight="800" fill="#ffffff" letter-spacing="-1">PM Skills</text>
   <rect x="95" y="158" width="210" height="6" rx="3" fill="url(#accent)"/>
-  <text x="92" y="200" font-size="26" fill="#e7e0ff">822 professional skills your AI assistant can read.</text>
+  <text x="92" y="200" font-size="26" fill="#e7e0ff">832 professional skills your AI assistant can read.</text>
   <text x="92" y="234" font-size="19" fill="#a99fd6">Plain markdown · Claude · ChatGPT · Gemini · Cursor · Codex · MIT</text>
   <text x="92" y="278" font-size="17" fill="#7fe3db">npx pm-claude-skills add</text>
   <rect x="80" y="258" width="270" height="30" rx="8" fill="none" stroke="#4ecdc4" stroke-opacity=".5"/>


### PR DESCRIPTION
## What does this PR add or change?

Makes the README more exciting for a first-time visitor, and fixes the stale banner count.

## Changes
- **Banner fixed** — `hero.svg` had a baked-in **"822 professional skills"**; bumped to **832** (it's a static asset updated per release, not drift-checked, so it lagged).
- **New "✨ See it in action" showcase** — placed right after the onboarding "🐣 New here? Pick a door" section, so a newcomer gets an immediate *wow* before the details. Two **count-free, current** GIFs, each linking to its live in-browser page:
  - 🌌 **Galaxy 3D** — fly through all 832 skills as a glowing constellation
  - 🎁 **Wrapped** — your practice as a shareable, local-only story
  - plus a Playground CTA.
- The README previously used **zero GIFs** — this is the first visual demo above the fold.

## Why these GIFs
Most of the existing demo GIFs bake in an old skill count (e.g. "180 skills") that would contradict the 832 banner. I deliberately chose the two spectacle GIFs that show **no stale number**, so the visuals stay correct release-to-release.

## Testing
- `check-drift`: **clean** — 832 skills / 104 bundles consistent (the new copy references 832).
- Links verified: `galaxy3d.html`, `wrapped.html`, and the Playground all exist.

## Note — the GitHub "About" (sidebar) still says 515
The repo's **About description** (the sidebar on the repo page) reads *"…515 professional Agent Skills…"* — that's set in repo settings, not in a file, so it can't be changed via a PR. See my message for the corrected text to paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_