### PR TITLE
feat(site): Vercel newsletter + skill catalogue site

### DIFF
--- a/.github/workflows/newsletter-on-release.yml
+++ b/.github/workflows/newsletter-on-release.yml
@@ -1,0 +1,61 @@
+name: Newsletter draft on release
+
+# When you publish a GitHub Release, this drafts a newsletter in Buttondown from
+# the release notes — so subscribers can be told about new skills. It creates a
+# DRAFT (never auto-sends), so you review and hit send in Buttondown yourself.
+#
+# Setup: add a repo secret BUTTONDOWN_API_KEY (Buttondown → Settings → API).
+# Without the secret, the job skips cleanly.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to draft from (e.g. v69.0.0)'
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Draft the newsletter
+        env:
+          BUTTONDOWN_API_KEY: ${{ secrets.BUTTONDOWN_API_KEY }}
+          REL_NAME: ${{ github.event.release.name }}
+          REL_TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
+          REL_BODY: ${{ github.event.release.body }}
+          REL_URL: ${{ github.event.release.html_url }}
+        run: |
+          if [ -z "$BUTTONDOWN_API_KEY" ]; then
+            echo "No BUTTONDOWN_API_KEY secret set — skipping newsletter draft."
+            exit 0
+          fi
+
+          SUBJECT="New skills: ${REL_NAME:-$REL_TAG}"
+          # Fall back to a friendly note if the release had no body.
+          INTRO="${REL_BODY:-New skills just landed in PM Skills ($REL_TAG).}"
+          FOOTER=$'\n\n—\nBrowse the catalogue: https://mohitagw15856.github.io/pm-claude-skills/\nFull release: '"${REL_URL:-https://github.com/mohitagw15856/pm-claude-skills/releases}"
+          BODY="${INTRO}${FOOTER}"
+
+          # Build the JSON payload safely (jq escapes newlines/quotes).
+          payload=$(jq -n --arg s "$SUBJECT" --arg b "$BODY" \
+            '{subject: $s, body: $b, status: "draft"}')
+
+          code=$(curl -sS -o /tmp/resp.json -w "%{http_code}" \
+            -X POST https://api.buttondown.email/v1/emails \
+            -H "Authorization: Token $BUTTONDOWN_API_KEY" \
+            -H "Content-Type: application/json" \
+            -d "$payload")
+
+          echo "Buttondown responded $code"
+          if [ "$code" = "201" ] || [ "$code" = "200" ]; then
+            echo "✓ Draft newsletter created in Buttondown — review and send it there."
+          else
+            echo "::warning::Buttondown draft not created (HTTP $code). Response:"; cat /tmp/resp.json || true
+            # Don't fail the release over a newsletter draft.
+          fi

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,47 @@
+# PM Skills — website & newsletter
+
+A simple, framework-free site to host on **Vercel**:
+
+- **Home** (`index.html`) — value prop + newsletter signup + featured skills.
+- **Catalogue** (`catalogue.html`) — searchable, filterable grid of every skill, loaded **live** from the canonical `skills.json` (so new releases show up with no redeploy).
+- **Skill detail** (`skill.html?name=<skill>`) — what it produces, what it needs, a live "run it in the Playground" example, related skills, and the full skill text.
+- **Newsletter** — a `/api/subscribe` serverless function that adds emails to **Buttondown**.
+
+No build step. Static files + one function.
+
+## Deploy to Vercel (5 minutes)
+
+1. **New Project** in Vercel → import this repo (`mohitagw15856/pm-claude-skills`).
+2. Set **Root Directory** to **`site`**. *(This keeps it separate from the main `web/` deploy at the repo root.)*
+3. Framework preset: **Other** (it's static). No build command, output directory `.` — already set in `site/vercel.json`.
+4. Add an **Environment Variable**:
+   - `BUTTONDOWN_API_KEY` — from Buttondown → **Settings → API**.
+5. Deploy. Your site is live; the signup form posts to `/api/subscribe` → Buttondown.
+
+> The catalogue fetches `https://mohitagw15856.github.io/pm-claude-skills/skills.json` at runtime, so it always shows the current library. To pin it to a snapshot instead, change `CATALOG_URL` in `assets/app.js`.
+
+## Auto-announce new skills
+
+The repo workflow [`.github/workflows/newsletter-on-release.yml`](../.github/workflows/newsletter-on-release.yml) turns each **GitHub Release** into a **draft** newsletter in Buttondown (it never auto-sends — you review and hit send).
+
+- Add the same **`BUTTONDOWN_API_KEY`** as a **repo secret** (Settings → Secrets and variables → Actions).
+- Publish a release → a draft appears in Buttondown with the release notes → you send it.
+- You can also run it manually (Actions → *Newsletter draft on release* → Run workflow) against an existing tag.
+
+## Local preview
+
+Any static server works, e.g.:
+
+```bash
+cd site && npx serve .      # or: python3 -m http.server
+```
+
+The `/api/subscribe` function only runs on Vercel (or `vercel dev`). Locally the form will 404 on submit — that's expected; the catalogue and pages work fully.
+
+## Customise
+
+- **Featured skills** on the home page: edit the `FEATURED` array in `assets/app.js`.
+- **Colours**: the `--accent` tokens in `assets/styles.css` (matches the library's `#d9605a`).
+- **Copy**: all in the three `.html` files.
+
+MIT © Mohit Aggarwal

--- a/site/api/subscribe.js
+++ b/site/api/subscribe.js
@@ -1,0 +1,49 @@
+// Vercel serverless function: POST /api/subscribe { email }
+// Adds the email to your Buttondown newsletter. Set BUTTONDOWN_API_KEY in the
+// Vercel project's Environment Variables. Nothing is stored on this server.
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ ok: false, error: 'Method not allowed' });
+  }
+
+  // Body may arrive parsed (Vercel) or as a string.
+  let body = req.body;
+  if (typeof body === 'string') { try { body = JSON.parse(body); } catch { body = {}; } }
+  const email = (body && body.email ? String(body.email) : '').trim().toLowerCase();
+
+  // Minimal, honest validation.
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return res.status(400).json({ ok: false, error: 'Please enter a valid email address.' });
+  }
+
+  const key = process.env.BUTTONDOWN_API_KEY;
+  if (!key) {
+    // Fail loudly for the operator, softly for the visitor.
+    console.error('BUTTONDOWN_API_KEY is not set.');
+    return res.status(500).json({ ok: false, error: 'Newsletter is not configured yet. Try again soon.' });
+  }
+
+  try {
+    const r = await fetch('https://api.buttondown.email/v1/subscribers', {
+      method: 'POST',
+      headers: { Authorization: `Token ${key}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email_address: email, tags: ['pm-skills-web'] }),
+    });
+
+    if (r.status === 201 || r.status === 200) {
+      return res.status(200).json({ ok: true, status: 'subscribed' });
+    }
+    // Buttondown returns 400 with a code when the address already exists.
+    const data = await r.json().catch(() => ({}));
+    const code = data && (data.code || (data.detail || ''));
+    if (r.status === 400 && /exist|already/i.test(JSON.stringify(data))) {
+      return res.status(200).json({ ok: true, status: 'already' });
+    }
+    console.error('Buttondown error', r.status, data);
+    return res.status(502).json({ ok: false, error: 'Could not subscribe right now. Please try again.' });
+  } catch (e) {
+    console.error('subscribe failed', e);
+    return res.status(502).json({ ok: false, error: 'Network error. Please try again.' });
+  }
+}

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -1,0 +1,169 @@
+// Shared client logic for the PM Skills site. No framework, no build step.
+// The catalogue is fetched live from the canonical skills.json, so this site
+// always reflects the latest release without a redeploy.
+const CATALOG_URL = 'https://mohitagw15856.github.io/pm-claude-skills/skills.json';
+const PLAYGROUND = 'https://mohitagw15856.github.io/pm-claude-skills';
+const REPO = 'https://github.com/mohitagw15856/pm-claude-skills';
+
+const esc = (s) => String(s == null ? '' : s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+const qs = (k) => new URLSearchParams(location.search).get(k);
+const byName = (skills, n) => skills.find((s) => s.name === n);
+
+let CATALOG = null;
+async function catalog() {
+  if (CATALOG) return CATALOG;
+  const res = await fetch(CATALOG_URL, { cache: 'no-store' });
+  if (!res.ok) throw new Error('catalog ' + res.status);
+  const data = await res.json();
+  CATALOG = { count: data.count, skills: data.skills || [] };
+  return CATALOG;
+}
+
+const TIER_LABEL = { production: '🏆 Production-ready', stable: '✓ Stable', experimental: '⚗ Experimental' };
+const prettyBundle = (p) => (p || '').replace(/^pm-/, '').replace(/(^|\s)\S/g, (m) => m.toUpperCase());
+const evalScore = (s) => (s && s.eval && typeof s.eval.score === 'number') ? s.eval.score : null;
+
+function card(s) {
+  const tier = TIER_LABEL[s.tier] || s.tier || '';
+  const sc = evalScore(s);
+  return `<a class="card" href="skill.html?name=${encodeURIComponent(s.name)}">
+    <div class="card-top"><span class="bundle">${esc(prettyBundle(s.plugin))}</span>${sc ? `<span class="score">★ ${sc}</span>` : ''}</div>
+    <h3>${esc(s.title || s.name)}</h3>
+    <p>${esc(s.summary || (s.description || '').slice(0, 140))}</p>
+    <span class="tier">${esc(tier)}</span>
+  </a>`;
+}
+
+// ---- Catalogue page -------------------------------------------------------
+async function initCatalogue() {
+  const grid = document.getElementById('grid');
+  const searchEl = document.getElementById('search');
+  const bundleEl = document.getElementById('bundleFilter');
+  const tierEl = document.getElementById('tierFilter');
+  const countEl = document.getElementById('resultCount');
+  let data;
+  try { data = await catalog(); } catch (e) { grid.innerHTML = `<p class="err">Couldn't load the catalogue. <a href="${CATALOG_URL}">Open the raw data →</a></p>`; return; }
+
+  const bundles = [...new Set(data.skills.map((s) => s.plugin))].sort();
+  bundleEl.innerHTML = '<option value="">All bundles</option>' + bundles.map((b) => `<option value="${esc(b)}">${esc(prettyBundle(b))}</option>`).join('');
+
+  function render() {
+    const q = (searchEl.value || '').toLowerCase().trim();
+    const b = bundleEl.value, t = tierEl.value;
+    const out = data.skills.filter((s) => {
+      if (b && s.plugin !== b) return false;
+      if (t && s.tier !== t) return false;
+      if (!q) return true;
+      return (s.name + ' ' + (s.title || '') + ' ' + (s.description || '') + ' ' + (s.summary || '')).toLowerCase().includes(q);
+    });
+    countEl.textContent = `${out.length} skill${out.length === 1 ? '' : 's'}`;
+    grid.innerHTML = out.length ? out.slice(0, 600).map(card).join('') : '<p class="err">No skills match. Try a broader search.</p>';
+  }
+  [searchEl, bundleEl, tierEl].forEach((el) => el.addEventListener('input', render));
+  const preset = qs('q'); if (preset) searchEl.value = preset;
+  render();
+}
+
+// ---- Skill detail page ----------------------------------------------------
+function exampleFor(s) {
+  // Build a realistic "try this" prompt from the skill's own inputs.
+  const first = (s.inputs || []).find((i) => !i.optional) || (s.inputs || [])[0];
+  if (first && first.hint) return `${s.title}: ${first.hint}`;
+  return (s.description || '').split('.').slice(0, 1)[0];
+}
+
+async function initSkill() {
+  const wrap = document.getElementById('skill');
+  const name = qs('name');
+  let data; try { data = await catalog(); } catch (e) { wrap.innerHTML = '<p class="err">Couldn\'t load this skill.</p>'; return; }
+  const s = byName(data.skills, name);
+  if (!s) { wrap.innerHTML = `<p class="err">No skill named “${esc(name)}”. <a href="catalogue.html">Browse the catalogue →</a></p>`; return; }
+  document.title = `${s.title} · PM Skills`;
+
+  const inputs = (s.inputs || []).map((i) => `<li><b>${esc(i.label)}</b>${i.optional ? ' <span class="opt">(optional)</span>' : ''}${i.hint ? ` — <span class="hint">${esc(i.hint)}</span>` : ''}</li>`).join('');
+  const related = (s.related || []).map((n) => { const r = byName(data.skills, n); return r ? `<a class="chip" href="skill.html?name=${encodeURIComponent(n)}">${esc(r.title || n)}</a>` : ''; }).join('');
+  const runUrl = `${PLAYGROUND}/?skill=${encodeURIComponent(s.name)}`;
+
+  wrap.innerHTML = `
+    <a class="back" href="catalogue.html">← All skills</a>
+    <div class="detail-head">
+      <span class="bundle">${esc(prettyBundle(s.plugin))}</span>
+      <span class="tier">${esc(TIER_LABEL[s.tier] || s.tier || '')}</span>
+      ${evalScore(s) ? `<span class="score">★ ${evalScore(s)} eval</span>` : ''}
+    </div>
+    <h1>${esc(s.title || s.name)}</h1>
+    <p class="lead">${esc(s.description || s.summary || '')}</p>
+
+    <div class="power">
+      <div class="power-col">
+        <h2>What it needs</h2>
+        <ul class="inputs">${inputs || '<li>Just describe your task.</li>'}</ul>
+      </div>
+      <div class="power-col">
+        <h2>See its power</h2>
+        <p class="example-label">Try it with something like:</p>
+        <blockquote class="example">${esc(exampleFor(s))}</blockquote>
+        <a class="btn primary" href="${runUrl}" target="_blank" rel="noopener">▶ Run it live in the Playground</a>
+        <a class="btn ghost" href="${PLAYGROUND}/?skill=${encodeURIComponent(s.name)}&sample=1" target="_blank" rel="noopener">📄 See a sample output — no key</a>
+      </div>
+    </div>
+
+    ${s.instructions ? `<details class="instructions"><summary>Read the full skill (the framework it uses)</summary><pre>${esc(s.instructions)}</pre></details>` : ''}
+
+    ${related ? `<h2 class="rel-h">Related skills</h2><div class="chips">${related}</div>` : ''}
+
+    <div class="install">
+      <h2>Use it anywhere</h2>
+      <p>In Claude Code: <code>/plugin</code> → search <b>pm-skills</b>. Elsewhere: <code>npx pm-claude-skills add</code>. Or read the source: <a href="${REPO}/blob/main/skills/${encodeURIComponent(s.name)}/SKILL.md" target="_blank" rel="noopener">SKILL.md →</a></p>
+    </div>`;
+}
+
+// ---- Featured (home) ------------------------------------------------------
+const FEATURED = [
+  ['lease-decoder', 'Paste a lease → the traps, the money math, and what to ask, before you sign.'],
+  ['executive-update', 'Rough notes → a crisp exec briefing that leads with the one thing that matters.'],
+  ['incident-postmortem', 'A messy outage → a blameless timeline, root cause, and owned action items.'],
+  ['salary-negotiation', 'Rehearse the real conversation against a tough counterpart, then debrief.'],
+  ['decision-helper', 'Torn between two options → a weighted call and the one question that breaks the tie.'],
+  ['whats-for-dinner', "What's in the fridge → three dinners tonight, ranked by effort. No shopping trip."],
+];
+async function initFeatured() {
+  const el = document.getElementById('featured');
+  if (!el) return;
+  let data; try { data = await catalog(); } catch (e) { return; }
+  const countEl = document.getElementById('skillCount');
+  if (countEl) countEl.textContent = data.count || data.skills.length;
+  el.innerHTML = FEATURED.map(([n, ex]) => {
+    const s = byName(data.skills, n); if (!s) return '';
+    return `<a class="feature" href="skill.html?name=${encodeURIComponent(n)}">
+      <h3>${esc(s.title)}</h3><p>${esc(ex)}</p><span class="go">See its power →</span></a>`;
+  }).join('');
+}
+
+// ---- Newsletter form ------------------------------------------------------
+function initNewsletter() {
+  document.querySelectorAll('form.newsletter').forEach((form) => {
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const input = form.querySelector('input[type=email]');
+      const msg = form.querySelector('.nl-msg');
+      const btn = form.querySelector('button');
+      const email = input.value.trim();
+      msg.textContent = ''; msg.className = 'nl-msg'; btn.disabled = true; btn.dataset.label = btn.dataset.label || btn.textContent; btn.textContent = 'Subscribing…';
+      try {
+        const r = await fetch('/api/subscribe', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ email }) });
+        const data = await r.json().catch(() => ({}));
+        if (r.ok && data.ok) { msg.textContent = data.status === 'already' ? "You're already on the list — thanks! 💛" : "You're in! Watch your inbox when new skills drop. 🎉"; msg.classList.add('ok'); form.reset(); }
+        else { msg.textContent = data.error || 'Something went wrong. Please try again.'; msg.classList.add('bad'); }
+      } catch (err) { msg.textContent = 'Network error. Please try again.'; msg.classList.add('bad'); }
+      finally { btn.disabled = false; btn.textContent = btn.dataset.label; }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initNewsletter();
+  if (document.getElementById('grid')) initCatalogue();
+  if (document.getElementById('skill')) initSkill();
+  if (document.getElementById('featured')) initFeatured();
+});

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -1,0 +1,104 @@
+:root {
+  --accent: #d9605a; --accent-2: #e0855f;
+  --bg: #ffffff; --panel: #f7f7f5; --card: #ffffff; --border: #e6e6e2;
+  --text: #1a1a1a; --muted: #6b6b6b; --shadow: 0 1px 3px rgba(0,0,0,.06), 0 8px 24px rgba(0,0,0,.05);
+}
+@media (prefers-color-scheme: dark) {
+  :root { --bg:#0d1117; --panel:#161b22; --card:#161b22; --border:#2a313c; --text:#e7ebf0; --muted:#9aa4b2; --shadow:0 1px 3px rgba(0,0,0,.4); }
+}
+* { box-sizing: border-box; }
+body { margin: 0; font-family: -apple-system, "Segoe UI", Roboto, Inter, sans-serif; background: var(--bg); color: var(--text); line-height: 1.55; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+.wrap { max-width: 1080px; margin: 0 auto; padding: 0 22px; }
+img { max-width: 100%; }
+
+/* Nav */
+.nav { display: flex; align-items: center; gap: 18px; padding: 16px 22px; border-bottom: 1px solid var(--border); position: sticky; top: 0; background: color-mix(in srgb, var(--bg) 88%, transparent); backdrop-filter: blur(8px); z-index: 20; }
+.nav .brand { font-weight: 800; font-size: 18px; color: var(--text); }
+.nav .brand span { color: var(--accent); }
+.nav a { color: var(--muted); font-weight: 600; font-size: 14px; }
+.nav a:hover { color: var(--text); text-decoration: none; }
+.nav .spacer { flex: 1; }
+.nav .cta { background: var(--accent); color: #fff; padding: 7px 14px; border-radius: 8px; }
+.nav .cta:hover { background: var(--accent-2); text-decoration: none; }
+
+/* Hero */
+.hero { text-align: center; padding: 72px 0 40px; }
+.hero h1 { font-size: clamp(30px, 6vw, 52px); line-height: 1.08; margin: 0 0 16px; letter-spacing: -.02em; }
+.hero h1 .grad { background: linear-gradient(135deg, var(--accent), var(--accent-2)); -webkit-background-clip: text; background-clip: text; color: transparent; }
+.hero p.sub { font-size: clamp(16px, 2.4vw, 20px); color: var(--muted); max-width: 640px; margin: 0 auto 28px; }
+.hero .badges { display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; margin-top: 22px; color: var(--muted); font-size: 14px; }
+.hero .badges b { color: var(--text); }
+
+/* Newsletter */
+.nl-box { background: var(--panel); border: 1px solid var(--border); border-radius: 16px; padding: 28px; max-width: 560px; margin: 0 auto; box-shadow: var(--shadow); }
+.nl-box h2 { margin: 0 0 6px; font-size: 22px; }
+.nl-box p.small { color: var(--muted); font-size: 14px; margin: 0 0 16px; }
+form.newsletter { display: flex; gap: 8px; flex-wrap: wrap; }
+form.newsletter input[type=email] { flex: 1; min-width: 200px; padding: 12px 14px; border: 1px solid var(--border); border-radius: 10px; background: var(--bg); color: var(--text); font-size: 15px; }
+form.newsletter button { padding: 12px 20px; border: 0; border-radius: 10px; background: var(--accent); color: #fff; font-weight: 700; font-size: 15px; cursor: pointer; }
+form.newsletter button:hover { background: var(--accent-2); }
+form.newsletter button:disabled { opacity: .6; cursor: default; }
+.nl-msg { width: 100%; margin-top: 10px; font-size: 14px; min-height: 18px; }
+.nl-msg.ok { color: #1a7f37; } .nl-msg.bad { color: var(--accent); }
+@media (prefers-color-scheme: dark) { .nl-msg.ok { color: #3fb950; } }
+
+/* Sections */
+section.block { padding: 48px 0; }
+section.block h2.center { text-align: center; font-size: 28px; margin: 0 0 8px; }
+section.block p.center { text-align: center; color: var(--muted); margin: 0 0 28px; }
+
+/* Featured */
+.features { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
+.feature { display: block; background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px; box-shadow: var(--shadow); color: var(--text); }
+.feature:hover { border-color: var(--accent); text-decoration: none; transform: translateY(-2px); transition: .15s; }
+.feature h3 { margin: 0 0 8px; font-size: 18px; }
+.feature p { margin: 0 0 12px; color: var(--muted); font-size: 14.5px; }
+.feature .go { color: var(--accent); font-weight: 700; font-size: 14px; }
+
+/* Catalogue */
+.filters { display: flex; gap: 10px; flex-wrap: wrap; margin: 24px 0 8px; }
+.filters input, .filters select { padding: 11px 13px; border: 1px solid var(--border); border-radius: 10px; background: var(--card); color: var(--text); font-size: 15px; }
+.filters input { flex: 1; min-width: 220px; }
+.result-count { color: var(--muted); font-size: 14px; margin: 6px 0 16px; }
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 14px; }
+.card { display: flex; flex-direction: column; gap: 8px; background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 16px; color: var(--text); box-shadow: var(--shadow); }
+.card:hover { border-color: var(--accent); text-decoration: none; transform: translateY(-2px); transition: .12s; }
+.card-top { display: flex; justify-content: space-between; align-items: center; }
+.card h3 { margin: 0; font-size: 16px; }
+.card p { margin: 0; color: var(--muted); font-size: 13.5px; flex: 1; }
+.bundle { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; color: var(--accent); }
+.score { font-size: 12px; color: var(--muted); }
+.tier { font-size: 12px; color: var(--muted); }
+.err { color: var(--muted); padding: 30px 0; }
+
+/* Skill detail */
+.detail-head { display: flex; gap: 12px; align-items: center; margin: 8px 0; flex-wrap: wrap; }
+.back { display: inline-block; margin: 20px 0 8px; color: var(--muted); font-weight: 600; }
+#skill h1 { font-size: clamp(26px, 4vw, 40px); margin: 8px 0 10px; letter-spacing: -.02em; }
+#skill .lead { font-size: 18px; color: var(--muted); max-width: 760px; }
+.power { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin: 28px 0; }
+@media (max-width: 700px) { .power { grid-template-columns: 1fr; } }
+.power-col { background: var(--panel); border: 1px solid var(--border); border-radius: 14px; padding: 20px; }
+.power-col h2 { margin: 0 0 12px; font-size: 17px; }
+.inputs { margin: 0; padding-left: 18px; } .inputs li { margin: 6px 0; font-size: 14.5px; }
+.inputs .opt { color: var(--muted); font-size: 12px; } .inputs .hint { color: var(--muted); }
+.example-label { color: var(--muted); font-size: 13px; margin: 0 0 6px; }
+.example { margin: 0 0 16px; padding: 12px 14px; border-left: 3px solid var(--accent); background: var(--bg); border-radius: 0 8px 8px 0; font-style: italic; }
+.btn { display: block; text-align: center; padding: 11px 16px; border-radius: 10px; font-weight: 700; margin: 8px 0; }
+.btn.primary { background: var(--accent); color: #fff; } .btn.primary:hover { background: var(--accent-2); text-decoration: none; }
+.btn.ghost { background: transparent; border: 1px solid var(--border); color: var(--text); } .btn.ghost:hover { border-color: var(--accent); text-decoration: none; }
+.instructions { margin: 20px 0; border: 1px solid var(--border); border-radius: 12px; padding: 4px 16px; background: var(--panel); }
+.instructions summary { cursor: pointer; font-weight: 700; padding: 12px 0; }
+.instructions pre { white-space: pre-wrap; font-size: 13px; line-height: 1.5; color: var(--text); overflow-x: auto; }
+.rel-h { font-size: 18px; margin: 24px 0 10px; }
+.chips { display: flex; gap: 8px; flex-wrap: wrap; }
+.chip { background: var(--panel); border: 1px solid var(--border); border-radius: 999px; padding: 6px 13px; font-size: 13px; color: var(--text); }
+.chip:hover { border-color: var(--accent); text-decoration: none; }
+.install { margin: 32px 0; padding: 20px; background: var(--panel); border: 1px solid var(--border); border-radius: 14px; }
+.install code { background: var(--bg); border: 1px solid var(--border); border-radius: 6px; padding: 2px 7px; font-size: 13px; }
+
+/* Footer */
+footer { border-top: 1px solid var(--border); margin-top: 60px; padding: 30px 0; color: var(--muted); font-size: 14px; text-align: center; }
+footer a { color: var(--muted); } footer a:hover { color: var(--text); }

--- a/site/catalogue.html
+++ b/site/catalogue.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Catalogue — PM Skills</title>
+  <meta name="description" content="Browse the full catalogue of professional Agent Skills. Search by task or filter by profession and tier." />
+  <link rel="stylesheet" href="/assets/styles.css" />
+</head>
+<body>
+  <nav class="nav">
+    <a class="brand" href="/">🧠 PM <span>Skills</span></a>
+    <a href="/catalogue.html">Catalogue</a>
+    <a href="https://mohitagw15856.github.io/pm-claude-skills/" target="_blank" rel="noopener">Playground</a>
+    <div class="spacer"></div>
+    <a class="cta" href="/#subscribe">Get the newsletter</a>
+  </nav>
+
+  <main class="wrap" style="padding-top:28px;">
+    <h1 style="margin:8px 0;">The skill catalogue</h1>
+    <p style="color:var(--muted);margin:0;">Every skill turns a rough input into a professional-grade output. Search, or filter by profession and maturity.</p>
+
+    <div class="filters">
+      <input id="search" type="search" placeholder="Search 800+ skills — e.g. lease, postmortem, negotiation…" aria-label="Search skills" />
+      <select id="bundleFilter" aria-label="Filter by bundle"></select>
+      <select id="tierFilter" aria-label="Filter by tier">
+        <option value="">All tiers</option>
+        <option value="production">🏆 Production-ready</option>
+        <option value="stable">✓ Stable</option>
+        <option value="experimental">⚗ Experimental</option>
+      </select>
+    </div>
+    <div class="result-count" id="resultCount">Loading…</div>
+    <div class="grid" id="grid"></div>
+  </main>
+
+  <footer>
+    <p><a href="/">Home</a> · <a href="https://github.com/mohitagw15856/pm-claude-skills" target="_blank" rel="noopener">GitHub</a> · <a href="https://mohitagw15856.github.io/pm-claude-skills/" target="_blank" rel="noopener">Playground</a></p>
+  </footer>
+  <script src="/assets/app.js"></script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>PM Skills — professional Agent Skills for your AI, and a newsletter when new ones drop</title>
+  <meta name="description" content="A growing library of professional Agent Skills — plain SKILL.md files that teach your AI to do one professional task properly. Browse the catalogue, see each skill's power, and get an email when new skills launch." />
+  <meta property="og:title" content="PM Skills — professional Agent Skills + new-skill newsletter" />
+  <meta property="og:description" content="Browse the catalogue, see each skill's power with an example, and subscribe to hear when new skills launch." />
+  <link rel="stylesheet" href="/assets/styles.css" />
+</head>
+<body>
+  <nav class="nav">
+    <a class="brand" href="/">🧠 PM <span>Skills</span></a>
+    <a href="/catalogue.html">Catalogue</a>
+    <a href="https://mohitagw15856.github.io/pm-claude-skills/" target="_blank" rel="noopener">Playground</a>
+    <div class="spacer"></div>
+    <a class="cta" href="#subscribe">Get the newsletter</a>
+  </nav>
+
+  <header class="hero wrap">
+    <h1>Give your AI the structure a <span class="grad">senior professional</span> actually uses.</h1>
+    <p class="sub">A growing library of <b><span id="skillCount">800+</span> Agent Skills</b> — plain <code>SKILL.md</code> files that teach Claude, ChatGPT, Gemini, Cursor &amp; Codex to do one professional task properly. Browse the catalogue, see each skill's power, and get a heads-up when new ones drop.</p>
+    <div class="nl-box" id="subscribe">
+      <h2>📬 New skills, in your inbox</h2>
+      <p class="small">A short email whenever new skills launch — what they do and how to use them. No spam, unsubscribe anytime.</p>
+      <form class="newsletter">
+        <input type="email" required placeholder="you@example.com" aria-label="Email address" />
+        <button type="submit">Subscribe</button>
+        <div class="nl-msg" role="status" aria-live="polite"></div>
+      </form>
+    </div>
+    <div class="badges">
+      <span><b id="skillCount2"></b></span>
+      <span>·&nbsp; MIT licensed</span>
+      <span>·&nbsp; Works with <b>Claude · ChatGPT · Gemini · Cursor · Codex</b></span>
+      <span>·&nbsp; <a href="https://mohitagw15856.github.io/pm-claude-skills/" target="_blank" rel="noopener">Run any one free</a></span>
+    </div>
+  </header>
+
+  <section class="block wrap">
+    <h2 class="center">See the power of a skill</h2>
+    <p class="center">Each skill turns a rough input into a senior-grade artifact. A few favourites:</p>
+    <div class="features" id="featured"></div>
+    <p class="center" style="margin-top:28px"><a class="cta" href="/catalogue.html" style="padding:11px 20px;border-radius:10px;">Browse the full catalogue →</a></p>
+  </section>
+
+  <section class="block wrap" style="background:var(--panel);border-radius:18px;">
+    <h2 class="center">How it works</h2>
+    <div class="features">
+      <div class="feature"><h3>1 · Find the skill</h3><p>Search the catalogue by task or profession. Every skill says exactly what it produces and what it needs.</p></div>
+      <div class="feature"><h3>2 · Run it anywhere</h3><p>Try it free in the browser Playground, or install: <code>/plugin</code> in Claude Code, or <code>npx pm-claude-skills add</code>.</p></div>
+      <div class="feature"><h3>3 · Stay current</h3><p>Subscribe once and get an email each time new skills launch — so your toolkit keeps growing.</p></div>
+    </div>
+  </section>
+
+  <footer>
+    <p><a href="/catalogue.html">Catalogue</a> · <a href="https://github.com/mohitagw15856/pm-claude-skills" target="_blank" rel="noopener">GitHub</a> · <a href="https://mohitagw15856.github.io/pm-claude-skills/" target="_blank" rel="noopener">Playground</a> · <a href="#subscribe">Newsletter</a></p>
+    <p>Open-source · MIT · Built by a PM, used by everyone.</p>
+  </footer>
+
+  <script src="/assets/app.js"></script>
+  <script>document.addEventListener('DOMContentLoaded',()=>{const c=document.getElementById('skillCount');const obs=new MutationObserver(()=>{const n=c.textContent;const b=document.getElementById('skillCount2');if(b)b.textContent=n+' skills';});obs.observe(c,{childList:true});});</script>
+</body>
+</html>

--- a/site/package.json
+++ b/site/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "pm-skills-site",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "PM Skills catalogue + newsletter site (static + one serverless function). Deploy on Vercel with Root Directory = site.",
+  "license": "MIT"
+}

--- a/site/skill.html
+++ b/site/skill.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Skill — PM Skills</title>
+  <meta name="description" content="What this skill produces, what it needs, and how to run it — with a live example." />
+  <link rel="stylesheet" href="/assets/styles.css" />
+</head>
+<body>
+  <nav class="nav">
+    <a class="brand" href="/">🧠 PM <span>Skills</span></a>
+    <a href="/catalogue.html">Catalogue</a>
+    <a href="https://mohitagw15856.github.io/pm-claude-skills/" target="_blank" rel="noopener">Playground</a>
+    <div class="spacer"></div>
+    <a class="cta" href="/#subscribe">Get the newsletter</a>
+  </nav>
+
+  <main class="wrap" id="skill" style="padding-bottom:40px;">
+    <p class="err">Loading…</p>
+  </main>
+
+  <section class="wrap" style="max-width:560px;padding-bottom:40px;">
+    <div class="nl-box" id="subscribe">
+      <h2>📬 Get new skills in your inbox</h2>
+      <p class="small">A short email when new skills launch. No spam.</p>
+      <form class="newsletter">
+        <input type="email" required placeholder="you@example.com" aria-label="Email address" />
+        <button type="submit">Subscribe</button>
+        <div class="nl-msg" role="status" aria-live="polite"></div>
+      </form>
+    </div>
+  </section>
+
+  <footer>
+    <p><a href="/">Home</a> · <a href="/catalogue.html">Catalogue</a> · <a href="https://github.com/mohitagw15856/pm-claude-skills" target="_blank" rel="noopener">GitHub</a></p>
+  </footer>
+  <script src="/assets/app.js"></script>
+</body>
+</html>

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "framework": null,
+  "buildCommand": null,
+  "outputDirectory": "."
+}


### PR DESCRIPTION
## What does this PR add?

A simple **Vercel-hostable website** (`site/`) with a **new-skill newsletter**, a **searchable catalogue**, and a **"see the power" page for every skill** — separate from the existing `web/` deploy.

## What's in it
- **Home** (`site/index.html`) — value prop, newsletter signup, featured skills, live skill count.
- **Catalogue** (`site/catalogue.html`) — searchable + filterable (by profession & tier) grid of every skill, loaded **live from `skills.json`**, so it always reflects the latest release **with no redeploy**.
- **Skill detail** (`site/skill.html?name=…`) — **what it produces, what it needs** (from each skill's structured `inputs`), a **live example** with "▶ Run it in the Playground" + "See a sample output," related skills, and the full skill text.
- **Newsletter** — `site/api/subscribe.js` serverless function → **Buttondown** (validates email, handles already-subscribed, no server-side storage).
- **Auto-announce** — `.github/workflows/newsletter-on-release.yml` turns each GitHub Release into a **draft** Buttondown newsletter (never auto-sends; skips cleanly without the secret).
- **`site/README.md`** — 5-minute deploy steps.

No framework, no build step — static files + one function. Theme-aware, on-brand (`#d9605a`).

## Deploy (from `site/README.md`)
1. New Vercel project → import this repo → **Root Directory = `site`**.
2. Add env var **`BUTTONDOWN_API_KEY`** (Buttondown → Settings → API).
3. Deploy. For auto-announce, add the same key as a **repo secret** `BUTTONDOWN_API_KEY`.

## Testing
- Subscribe function unit-tested: invalid email → 400, missing key → 500, valid → 200 `subscribed`, already-subscribed → 200 `already`, wrong method → 405.
- Workflow YAML validated.
- All three pages rendered headless against the live catalogue shape — screenshots confirmed layout, the dynamic count, filters, and the per-skill "power" panel. Fixed an `eval` object → `.score` render bug found in review.

## Note
Deliberately **not** wired into the repo's release-version machinery (it's a standalone site, not part of the npm/MCP/PyPI package), so no version bump or CHANGELOG change — it won't affect the library's CI gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_