### PR TITLE
feat(site): Buttondown free-plan support (clean redo of #215)

### DIFF
--- a/site/.gitignore
+++ b/site/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+node_modules

--- a/site/README.md
+++ b/site/README.md
@@ -14,8 +14,9 @@ No build step. Static files + one function.
 1. **New Project** in Vercel → import this repo (`mohitagw15856/pm-claude-skills`).
 2. Set **Root Directory** to **`site`**. *(This keeps it separate from the main `web/` deploy at the repo root.)*
 3. Framework preset: **Other** (it's static). No build command, output directory `.` — already set in `site/vercel.json`.
-4. Add an **Environment Variable**:
-   - `BUTTONDOWN_API_KEY` — from Buttondown → **Settings → API**.
+4. Add **one** Environment Variable (either works):
+   - **Free plan:** `BUTTONDOWN_USERNAME` — your Buttondown handle (the `buttondown.com/<username>`). The signup posts to Buttondown's public embed endpoint — no API key, no paid plan.
+   - **Paid plan:** `BUTTONDOWN_API_KEY` — from Buttondown → **Settings → API/Programming** (only on paid plans; adds tag support). If both are set, the API key wins.
 5. Deploy. Your site is live; the signup form posts to `/api/subscribe` → Buttondown.
 
 > The catalogue fetches `https://mohitagw15856.github.io/pm-claude-skills/skills.json` at runtime, so it always shows the current library. To pin it to a snapshot instead, change `CATALOG_URL` in `assets/app.js`.

--- a/site/api/subscribe.js
+++ b/site/api/subscribe.js
@@ -17,31 +17,43 @@ export default async function handler(req, res) {
     return res.status(400).json({ ok: false, error: 'Please enter a valid email address.' });
   }
 
-  const key = process.env.BUTTONDOWN_API_KEY;
-  if (!key) {
-    // Fail loudly for the operator, softly for the visitor.
-    console.error('BUTTONDOWN_API_KEY is not set.');
-    return res.status(500).json({ ok: false, error: 'Newsletter is not configured yet. Try again soon.' });
-  }
+  const key = process.env.BUTTONDOWN_API_KEY;   // paid plans (preferred)
+  const user = process.env.BUTTONDOWN_USERNAME;  // free plans: public embed endpoint
 
   try {
-    const r = await fetch('https://api.buttondown.email/v1/subscribers', {
-      method: 'POST',
-      headers: { Authorization: `Token ${key}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email_address: email, tags: ['pm-skills-web'] }),
-    });
+    // Path A — API key (paid): richest, supports tags.
+    if (key) {
+      const r = await fetch('https://api.buttondown.email/v1/subscribers', {
+        method: 'POST',
+        headers: { Authorization: `Token ${key}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email_address: email, tags: ['pm-skills-web'] }),
+      });
+      if (r.status === 201 || r.status === 200) return res.status(200).json({ ok: true, status: 'subscribed' });
+      const data = await r.json().catch(() => ({}));
+      if (r.status === 400 && /exist|already/i.test(JSON.stringify(data))) return res.status(200).json({ ok: true, status: 'already' });
+      console.error('Buttondown API error', r.status, data);
+      return res.status(502).json({ ok: false, error: 'Could not subscribe right now. Please try again.' });
+    }
 
-    if (r.status === 201 || r.status === 200) {
-      return res.status(200).json({ ok: true, status: 'subscribed' });
+    // Path B — free plan: post to the public embed-subscribe endpoint (no key).
+    if (user) {
+      const form = new URLSearchParams({ email, tag: 'pm-skills-web' });
+      const r = await fetch(`https://buttondown.com/api/emails/embed-subscribe/${encodeURIComponent(user)}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: form.toString(),
+        redirect: 'manual',
+      });
+      // The embed endpoint returns 200 or a 3xx redirect to a confirmation page on success.
+      if (r.status === 200 || (r.status >= 300 && r.status < 400)) return res.status(200).json({ ok: true, status: 'subscribed' });
+      const text = await r.text().catch(() => '');
+      if (/already/i.test(text)) return res.status(200).json({ ok: true, status: 'already' });
+      console.error('Buttondown embed error', r.status, text.slice(0, 200));
+      return res.status(502).json({ ok: false, error: 'Could not subscribe right now. Please try again.' });
     }
-    // Buttondown returns 400 with a code when the address already exists.
-    const data = await r.json().catch(() => ({}));
-    const code = data && (data.code || (data.detail || ''));
-    if (r.status === 400 && /exist|already/i.test(JSON.stringify(data))) {
-      return res.status(200).json({ ok: true, status: 'already' });
-    }
-    console.error('Buttondown error', r.status, data);
-    return res.status(502).json({ ok: false, error: 'Could not subscribe right now. Please try again.' });
+
+    console.error('Neither BUTTONDOWN_API_KEY nor BUTTONDOWN_USERNAME is set.');
+    return res.status(500).json({ ok: false, error: 'Newsletter is not configured yet. Try again soon.' });
   } catch (e) {
     console.error('subscribe failed', e);
     return res.status(502).json({ ok: false, error: 'Network error. Please try again.' });


### PR DESCRIPTION
## What does this PR add or change?

Adds **Buttondown free-plan support** to the site's newsletter signup — a clean redo of the stuck **#215**.

## Why

**#214** shipped the site with a subscribe function that only used `BUTTONDOWN_API_KEY`, but that key is a **paid-only** Buttondown feature. On the free plan there's no key, so the newsletter couldn't work.

## The fix

`site/api/subscribe.js` now supports **two paths**:
- **Free plan:** if `BUTTONDOWN_USERNAME` is set, it posts to Buttondown's **public embed-subscribe endpoint** (`/api/emails/embed-subscribe/<user>`) — no key, no paid plan.
- **Paid plan:** if `BUTTONDOWN_API_KEY` is set, it uses the API (adds tag support). The key wins when both are present.

Also updates `site/README.md` (documents both env vars) and adds `site/.gitignore` (`.vercel`, `node_modules`).

## Note on #215

**#215 should be closed** — it's the old `claude/vercel-newsletter-site` branch, which now has an **add/add conflict** against the already-merged #214 (it tries to re-add `site/` files that main already has), and its body is the empty PR template. This PR replaces it cleanly off the latest `main`.

## Testing

- `node --check` passes.
- Unit-tested the subscribe logic: free path (no key + username, mocked 200 and 302 → `subscribed`), and the not-configured case → 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_