### PR TITLE
fix(site): use Buttondown iframe embed so free-plan signup works past…

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -5,21 +5,23 @@ A simple, framework-free site to host on **Vercel**:
 - **Home** (`index.html`) — value prop + newsletter signup + featured skills.
 - **Catalogue** (`catalogue.html`) — searchable, filterable grid of every skill, loaded **live** from the canonical `skills.json` (so new releases show up with no redeploy).
 - **Skill detail** (`skill.html?name=<skill>`) — what it produces, what it needs, a live "run it in the Playground" example, related skills, and the full skill text.
-- **Newsletter** — a `/api/subscribe` serverless function that adds emails to **Buttondown**.
+- **Newsletter** — Buttondown's official **iframe embed** widget (`buttondown.com/pm-skills?as_embed=true`). It runs client-side, so Buttondown's Cloudflare **Turnstile** bot-check completes in the visitor's browser and double opt-in works on the **free plan** — no API key, no env var, no server proxy.
 
-No build step. Static files + one function.
+No build step. Static files.
 
 ## Deploy to Vercel (5 minutes)
 
 1. **New Project** in Vercel → import this repo (`mohitagw15856/pm-claude-skills`).
-2. Set **Root Directory** to **`site`**. *(This keeps it separate from the main `web/` deploy at the repo root.)*
+2. Set **Root Directory** to **`site`**. *(This keeps it separate from the main `web/` deploy at the repo root, which serves the Playground.)*
 3. Framework preset: **Other** (it's static). No build command, output directory `.` — already set in `site/vercel.json`.
-4. Add **one** Environment Variable (either works):
-   - **Free plan:** `BUTTONDOWN_USERNAME` — your Buttondown handle (the `buttondown.com/<username>`). The signup posts to Buttondown's public embed endpoint — no API key, no paid plan.
-   - **Paid plan:** `BUTTONDOWN_API_KEY` — from Buttondown → **Settings → API/Programming** (only on paid plans; adds tag support). If both are set, the API key wins.
-5. Deploy. Your site is live; the signup form posts to `/api/subscribe` → Buttondown.
+4. Deploy. That's it — the newsletter widget is a Buttondown iframe that works with **no** env vars.
+
+> **Why an iframe and not a nice inline form?** Buttondown now guards its free subscribe endpoint with **Cloudflare Turnstile**. A server-side POST (the old `/api/subscribe` proxy) can't solve Turnstile, so it always failed with a 502. The iframe embed runs Turnstile *in the visitor's browser*, which is the only way subscriptions work on the free plan. To point the widget at a different Buttondown newsletter, change the `?as_embed=true` iframe `src` in `index.html` and `skill.html`.
 
 > The catalogue fetches `https://mohitagw15856.github.io/pm-claude-skills/skills.json` at runtime, so it always shows the current library. To pin it to a snapshot instead, change `CATALOG_URL` in `assets/app.js`.
+
+### Want the inline form back? (paid Buttondown only)
+The `site/api/subscribe.js` serverless function is still in the repo. If you upgrade Buttondown to a **paid plan**, set `BUTTONDOWN_API_KEY` (from **Settings → API**) as a Vercel env var and restore the `<form class="newsletter">` markup — the paid API has no Turnstile gate.
 
 ## Auto-announce new skills
 

--- a/site/assets/styles.css
+++ b/site/assets/styles.css
@@ -43,6 +43,8 @@ form.newsletter button:disabled { opacity: .6; cursor: default; }
 .nl-msg { width: 100%; margin-top: 10px; font-size: 14px; min-height: 18px; }
 .nl-msg.ok { color: #1a7f37; } .nl-msg.bad { color: var(--accent); }
 @media (prefers-color-scheme: dark) { .nl-msg.ok { color: #3fb950; } }
+/* Buttondown embed (runs Cloudflare Turnstile in-browser — the free-plan path). */
+.nl-embed { width: 100%; min-height: 180px; border: 0; border-radius: 10px; background: #fff; color-scheme: light; display: block; }
 
 /* Sections */
 section.block { padding: 48px 0; }

--- a/site/index.html
+++ b/site/index.html
@@ -24,11 +24,7 @@
     <div class="nl-box" id="subscribe">
       <h2>📬 New skills, in your inbox</h2>
       <p class="small">A short email whenever new skills launch — what they do and how to use them. No spam, unsubscribe anytime.</p>
-      <form class="newsletter">
-        <input type="email" required placeholder="you@example.com" aria-label="Email address" />
-        <button type="submit">Subscribe</button>
-        <div class="nl-msg" role="status" aria-live="polite"></div>
-      </form>
+      <iframe class="nl-embed" title="Subscribe to the PM Skills newsletter" src="https://buttondown.com/pm-skills?as_embed=true" scrolling="no" loading="lazy"></iframe>
     </div>
     <div class="badges">
       <span><b id="skillCount2"></b></span>

--- a/site/skill.html
+++ b/site/skill.html
@@ -24,11 +24,7 @@
     <div class="nl-box" id="subscribe">
       <h2>📬 Get new skills in your inbox</h2>
       <p class="small">A short email when new skills launch. No spam.</p>
-      <form class="newsletter">
-        <input type="email" required placeholder="you@example.com" aria-label="Email address" />
-        <button type="submit">Subscribe</button>
-        <div class="nl-msg" role="status" aria-live="polite"></div>
-      </form>
+      <iframe class="nl-embed" title="Subscribe to the PM Skills newsletter" src="https://buttondown.com/pm-skills?as_embed=true" scrolling="no" loading="lazy"></iframe>
     </div>
   </section>
 


### PR DESCRIPTION
… Turnstile

Buttondown now guards its free embed-subscribe endpoint with Cloudflare Turnstile. The server-side /api/subscribe proxy can't solve Turnstile, so every submit returned HTTP 400 from Buttondown -> 502 to the visitor.

Swap the custom fetch form on index.html and skill.html for Buttondown's official iframe embed widget (buttondown.com/pm-skills?as_embed=true). It runs Turnstile in the visitor's browser, which is the only way free-plan subscriptions complete. Add .nl-embed styling and update site/README with the why + a paid-plan path back to the inline form.


Claude-Session: https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

## What does this PR add or change?

<!-- One sentence summary -->

---

## Type of change

- [ ] New skill
- [ ] Improvement to an existing skill
- [ ] Bug fix (skill not triggering / wrong output)
- [ ] Documentation update (README, CONTRIBUTING, etc.)
- [ ] Marketplace / plugin config change
- [ ] Other: ___________

---

## New skill checklist

<!-- If you're adding a new skill, tick all of these before requesting review.
     If this isn't a new skill PR, delete this section. -->

**Skill file**
- [ ] Skill is in the correct folder: `plugins/[bundle-name]/skills/[skill-name]/SKILL.md`
- [ ] Frontmatter includes `name` and `description` fields
- [ ] `description` clearly states when Claude should activate this skill (trigger condition)
- [ ] `description` clearly states what the skill produces (output description)

**Content quality**
- [ ] Skill solves a real, recurring professional workflow (not a one-off task)
- [ ] Output structure is clearly defined with sections and format
- [ ] Required inputs are listed (what Claude should ask for if not provided)
- [ ] Quality checks section is included
- [ ] Example trigger phrases are included (at least 2)

**Safety**
- [ ] Skill contains no prompt injection attempts or instructions to override Claude's guidelines
- [ ] Skill does not instruct Claude to collect, store, or transmit personal data
- [ ] Skill does not contain hardcoded credentials, API keys, or PII

**Testing**
- [ ] I have tested this skill locally in Claude Code
- [ ] The skill triggers correctly on the example trigger phrases
- [ ] The output matches the structure defined in the SKILL.md

---

## What does this skill do?

<!-- 2-3 sentences. What workflow does it solve? Who is it for? -->

---

## Example output

<!-- Paste a real sample output from Claude when this skill was triggered, or describe what it produces.
     This is the most useful thing you can include for review. -->

---

## Which bundle does this belong in?

<!-- Which existing plugin bundle should this skill be added to?
     Or are you proposing a new bundle? -->

- [ ] pm-essentials
- [ ] pm-discovery
- [ ] pm-planning
- [ ] pm-delivery
- [ ] pm-analytics
- [ ] pm-strategy
- [ ] pm-advanced
- [ ] pm-rituals
- [ ] pm-gtm
- [ ] pm-engineering
- [ ] pm-data
- [ ] pm-people
- [ ] pm-design
- [ ] pm-business
- [ ] New bundle: ___________

---

## Related issue

<!-- If this PR addresses a skill request issue, link it here: "Closes #123" -->

---

## Anything else the reviewer should know?

<!-- Edge cases, limitations, or anything that might need discussion -->
