### PR TITLE
docs(readme): add a prominent Subscribe-to-newsletter button

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ Works natively in **Claude Code** and **Hermes Agent**, with ready-to-paste expo
 
 **Don't know what to look for?** Describe your task in plain words at **[🔎 find](https://mohitagw15856.github.io/pm-claude-skills/find.html)** — *"my landlord kept my deposit"*, *"board meeting on Thursday"* — and it names the skill.
 
+<p align="center">
+  <a href="https://site-jet-seven-34.vercel.app/#subscribe"><img src="https://img.shields.io/badge/📬_Get_the_newsletter-Subscribe_free-d9605a?style=for-the-badge" alt="Subscribe to the PM Skills newsletter"></a>
+</p>
+
+**Never miss a new skill.** New ones drop regularly — **[subscribe to the newsletter](https://site-jet-seven-34.vercel.app/#subscribe)** and get a short email with a real example whenever they launch. No spam, unsubscribe anytime.
+
 ## ✨ See it in action
 
 It's not just a folder of files — the whole library is explorable, runnable, and a little bit magic. All of this runs **in your browser, free, nothing to install:**


### PR DESCRIPTION
## What does this PR add or change?

Adds a prominent **Subscribe to the newsletter** button to the README, now that the signup works end-to-end.

---

## Type of change

- [x] Documentation update (README)

---

## Anything else the reviewer should know?

The newsletter signup now works on the free plan (Buttondown iframe embed that clears Cloudflare Turnstile in the browser), so the README should make subscribing one click:

- A centered **for-the-badge "📬 Get the newsletter — Subscribe free"** button, high on the page (right under the "find" prompt in the getting-started section).
- A short "**Never miss a new skill**" line with an inline subscribe link.

Both link to the catalogue site's `#subscribe` section (`site-jet-seven-34.vercel.app/#subscribe`), which hosts the working Buttondown embed. No skill counts added, so drift stays clean (`node scripts/check-drift.mjs` passes: 849 skills / 104 bundles).

> Note: the link uses the current Vercel URL. If a custom domain is added later, it's a one-line swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_