### PR TITLE
chore(release): v71.0.0 — version bump, v71 newsletter, site refresh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "pm-claude-skills",
-  "version": "70.0.0",
+  "version": "71.0.0",
   "description": "PM stands for Professional, not just Product Management. 515 Claude Skills + 4 agent templates across 74 bundles covering 31 professions — engineering, security, AI/ML, customer success, legal, government & policy, finance, personal finance, HR, sales, design, Figma, marketing, social media, writers, developer relations, founders/startups, healthcare, nonprofit, crisis comms, educators, content creators, and more. Built by a PM, used by everyone. Building blocks for the Anthropic agent template architecture.",
   "owner": {
     "name": "Mohit Aggarwal",

--- a/newsletters/v71.0.0.html
+++ b/newsletters/v71.0.0.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>9 new skills: get your money back 💷</title></head>
+<body style="margin:0;padding:0;background:#f4f1ee;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f1ee;padding:24px 12px;">
+<tr><td align="center">
+  <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.06);">
+    <!-- header -->
+    <tr><td style="background:linear-gradient(135deg,#d9605a,#b94a45);padding:28px 32px;">
+      <div style="font-size:20px;font-weight:800;color:#fff;letter-spacing:.2px;">📬 PM&nbsp;Skills</div>
+      <div style="font-size:13px;color:rgba(255,255,255,.9);margin-top:2px;">858 professional Agent Skills for your AI</div>
+    </td></tr>
+    <!-- hero -->
+    <tr><td style="padding:32px 32px 8px;">
+      <div style="display:inline-block;background:#fbeae8;color:#b94a45;font-size:12px;font-weight:700;padding:5px 12px;border-radius:999px;text-transform:uppercase;letter-spacing:.5px;">New release · v71.0.0</div>
+      <h1 style="margin:14px 0 4px;font-size:26px;line-height:1.25;color:#1a1a1a;">9 new skills: get your money back 💷</h1>
+    </td></tr>
+    <!-- body -->
+    <tr><td style="padding:8px 32px 4px;">
+      <p style="margin:10px 0;color:#333;line-height:1.6;font-size:15px;"><strong>Nine new skills this release — a "fight for your money" set plus the life-admin jobs everyone dreads.</strong></p>
+<h2 style="margin:22px 0 8px;font-size:18px;line-height:1.3;color:#1a1a1a;">💷 Get your money back</h2>
+<ul style="margin:8px 0 8px 0;padding-left:20px;">
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>warranty-claim</strong> — it broke just inside (or just outside) warranty; get the claim written, the proof to attach, and the consumer-law backstop for the brush-offs.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>price-match-request</strong> — found it cheaper, or the price dropped days after you bought? Claim the difference, with the exact evidence that qualifies.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>flight-delay-compensation</strong> — delayed, cancelled, or bumped? Find out if you are likely owed compensation (EU261 / UK / DOT-style) and send the claim.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>insurance-claim-appeal</strong> — a denial is often a first offer, not a verdict. Decode the reason, find the strongest grounds, and draft the appeal.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>late-invoice-chaser</strong> — freelancers: a warm→firm→formal sequence that gets an overdue invoice paid without torching the client.</li>
+</ul>
+<h2 style="margin:22px 0 8px;font-size:18px;line-height:1.3;color:#1a1a1a;">🏠 Life admin, handled</h2>
+<ul style="margin:8px 0 8px 0;padding-left:20px;">
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>small-claims-prep</strong> — the demand letter that often settles it, the evidence pack, the filing checklist, and a calm hearing script.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>moving-house-checklist</strong> — a backward-planned countdown: utilities, address changes, deposit recovery, packing waves.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>neighbor-dispute-resolver</strong> — de-escalate first, keep a paper trail, and know the real escalation path.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>product-recall-check</strong> — is your car, appliance, or car seat under a safety recall? Check the official sources and claim the free fix.</li>
+</ul>
+<h2 style="margin:22px 0 8px;font-size:18px;line-height:1.3;color:#1a1a1a;">🛰️ New: follow without email</h2>
+<p style="margin:10px 0;color:#333;line-height:1.6;font-size:15px;">Prefer no inbox? There is now an <strong>RSS/Atom feed</strong> of new skills and a <strong>public newsletter archive</strong> — subscribe in any reader, or read past issues at a permalink.</p>
+<p style="margin:10px 0;color:#333;line-height:1.6;font-size:15px;"><strong>Library: 858 skills across 105 bundles.</strong> MIT licensed. Try any free at https://mohitagw15856.github.io/pm-claude-skills/</p>
+    </td></tr>
+    <!-- CTAs -->
+    <tr><td style="padding:16px 32px 28px;">
+      <a href="https://mohitagw15856.github.io/pm-claude-skills/" style="display:inline-block;margin:6px 8px 6px 0;padding:12px 22px;border-radius:10px;font-weight:700;font-size:15px;text-decoration:none;background:#d9605a;color:#ffffff;">Explore the skills</a>
+      <a href="https://github.com/mohitagw15856/pm-claude-skills/releases/tag/v71.0.0" style="display:inline-block;margin:6px 8px 6px 0;padding:12px 22px;border-radius:10px;font-weight:700;font-size:15px;text-decoration:none;background:#ffffff;color:#d9605a;border:2px solid #d9605a;">Read the release</a>
+      <p style="margin:14px 0 0;font-size:13px;color:#888;">Or install into your AI tool: <code style="background:#f3f0ee;border-radius:4px;padding:1px 5px;">npx pm-claude-skills add</code></p>
+    </td></tr>
+    <!-- footer -->
+    <tr><td style="background:#faf8f6;padding:22px 32px;border-top:1px solid #f0ece9;">
+      <p style="margin:0 0 6px;font-size:13px;color:#999;">You're getting this because you subscribed for new-skill announcements at <a href="https://mohitagw15856.github.io/pm-claude-skills/" style="color:#d9605a;">PM Skills</a>.</p>
+      <p style="margin:0;font-size:13px;color:#999;"><a href="https://github.com/mohitagw15856/pm-claude-skills/releases/tag/v71.0.0" style="color:#999;">Full release notes</a> · <a href="https://github.com/mohitagw15856/pm-claude-skills" style="color:#999;">GitHub</a> · <a href="{{ unsubscribe_url }}" style="color:#999;">Unsubscribe</a></p>
+    </td></tr>
+  </table>
+  <div style="font-size:12px;color:#bbb;margin-top:14px;">MIT licensed · Made with care</div>
+</td></tr>
+</table>
+</body></html>

--- a/newsletters/v71.0.0.md
+++ b/newsletters/v71.0.0.md
@@ -1,0 +1,33 @@
+# 9 new skills: get your money back 💷
+
+_New release · v71.0.0 · now 858 skills_
+
+**Nine new skills this release — a "fight for your money" set plus the life-admin jobs everyone dreads.**
+
+## 💷 Get your money back
+
+- **warranty-claim** — it broke just inside (or just outside) warranty; get the claim written, the proof to attach, and the consumer-law backstop for the brush-offs.
+- **price-match-request** — found it cheaper, or the price dropped days after you bought? Claim the difference, with the exact evidence that qualifies.
+- **flight-delay-compensation** — delayed, cancelled, or bumped? Find out if you are likely owed compensation (EU261 / UK / DOT-style) and send the claim.
+- **insurance-claim-appeal** — a denial is often a first offer, not a verdict. Decode the reason, find the strongest grounds, and draft the appeal.
+- **late-invoice-chaser** — freelancers: a warm→firm→formal sequence that gets an overdue invoice paid without torching the client.
+
+## 🏠 Life admin, handled
+
+- **small-claims-prep** — the demand letter that often settles it, the evidence pack, the filing checklist, and a calm hearing script.
+- **moving-house-checklist** — a backward-planned countdown: utilities, address changes, deposit recovery, packing waves.
+- **neighbor-dispute-resolver** — de-escalate first, keep a paper trail, and know the real escalation path.
+- **product-recall-check** — is your car, appliance, or car seat under a safety recall? Check the official sources and claim the free fix.
+
+## 🛰️ New: follow without email
+
+Prefer no inbox? There is now an **RSS/Atom feed** of new skills and a **public newsletter archive** — subscribe in any reader, or read past issues at a permalink.
+
+**Library: 858 skills across 105 bundles.** MIT licensed. Try any free at https://mohitagw15856.github.io/pm-claude-skills/
+
+---
+
+**Explore the skills:** https://mohitagw15856.github.io/pm-claude-skills/
+**Install:** `npx pm-claude-skills add`
+
+Full release notes: https://github.com/mohitagw15856/pm-claude-skills/releases/tag/v71.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pm-claude-skills",
-  "version": "70.0.0",
+  "version": "71.0.0",
   "type": "module",
   "mcpName": "io.github.mohitagw15856/pm-claude-skills",
   "description": "858 professional Agent Skills (SKILL.md) + subagents + slash commands for Claude, ChatGPT, Gemini, Cursor, Codex & Hermes. It's a CLI, not a library: run `npx pm-claude-skills add --agent <tool>` to install into your AI tool — no `npm install` needed. Or try any skill free at https://mohitagw15856.github.io/pm-claude-skills/",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pm-skills"
-version = "0.36.0"
+version = "0.37.0"
 description = "206 professional Agent Skills (PRDs, launch plans, postmortems, rubrics, contracts…) as importable building blocks for Python AI agents — LangChain, CrewAI, LlamaIndex, or any framework."
 readme = "README.md"
 license = { text = "MIT" }

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/mohitagw15856/pm-claude-skills",
     "source": "github"
   },
-  "version": "70.0.0",
+  "version": "71.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "pm-claude-skills",
-      "version": "70.0.0",
+      "version": "71.0.0",
       "transport": {
         "type": "stdio"
       },

--- a/site/assets/app.js
+++ b/site/assets/app.js
@@ -126,6 +126,8 @@ const FEATURED = [
   ['salary-negotiation', 'Rehearse the real conversation against a tough counterpart, then debrief.'],
   ['decision-helper', 'Torn between two options → a weighted call and the one question that breaks the tie.'],
   ['whats-for-dinner', "What's in the fridge → three dinners tonight, ranked by effort. No shopping trip."],
+  ['lower-my-bill', 'Your provider hiked the price → a call script + the leverage that actually lowers the bill.'],
+  ['warranty-claim', 'It broke just out of warranty → the claim, the proof, and the consumer-law backstop.'],
 ];
 async function initFeatured() {
   const el = document.getElementById('featured');

--- a/site/catalogue.html
+++ b/site/catalogue.html
@@ -21,7 +21,7 @@
     <p style="color:var(--muted);margin:0;">Every skill turns a rough input into a professional-grade output. Search, or filter by profession and maturity.</p>
 
     <div class="filters">
-      <input id="search" type="search" placeholder="Search 800+ skills — e.g. lease, postmortem, negotiation…" aria-label="Search skills" />
+      <input id="search" type="search" placeholder="Search 850+ skills — e.g. lease, warranty, flight delay…" aria-label="Search skills" />
       <select id="bundleFilter" aria-label="Filter by bundle"></select>
       <select id="tierFilter" aria-label="Filter by tier">
         <option value="">All tiers</option>

--- a/site/index.html
+++ b/site/index.html
@@ -20,7 +20,7 @@
 
   <header class="hero wrap">
     <h1>Give your AI the structure a <span class="grad">senior professional</span> actually uses.</h1>
-    <p class="sub">A growing library of <b><span id="skillCount">800+</span> Agent Skills</b> — plain <code>SKILL.md</code> files that teach Claude, ChatGPT, Gemini, Cursor &amp; Codex to do one professional task properly. Browse the catalogue, see each skill's power, and get a heads-up when new ones drop.</p>
+    <p class="sub">A growing library of <b><span id="skillCount">850+</span> Agent Skills</b> — plain <code>SKILL.md</code> files that teach Claude, ChatGPT, Gemini, Cursor &amp; Codex to do one professional task properly. Browse the catalogue, see each skill's power, and get a heads-up when new ones drop.</p>
     <div class="nl-box" id="subscribe">
       <h2>📬 New skills, in your inbox</h2>
       <p class="small">A short email whenever new skills launch — what they do and how to use them. No spam, unsubscribe anytime.</p>

--- a/web/newsletters/index.html
+++ b/web/newsletters/index.html
@@ -21,6 +21,7 @@
   <h1>📬 Newsletter archive</h1>
   <p class="sub">Every "new skills" announcement, in one place.</p>
   <ul>
+      <li><a href="v71.0.0.html">9 new skills: get your money back 💷</a> <span class="tag">v71.0.0</span></li>
       <li><a href="v70.0.0.html">New skill: Lower My Bill 💸</a> <span class="tag">v70.0.0</span></li>
   </ul>
   <a class="feed" href="https://mohitagw15856.github.io/pm-claude-skills/feed.xml">🛰️ Prefer RSS? Follow new skills via the Atom feed — no email needed.</a>

--- a/web/newsletters/index.json
+++ b/web/newsletters/index.json
@@ -1,6 +1,11 @@
 {
-  "count": 1,
+  "count": 2,
   "issues": [
+    {
+      "tag": "v71.0.0",
+      "title": "9 new skills: get your money back 💷",
+      "href": "v71.0.0.html"
+    },
     {
       "tag": "v70.0.0",
       "title": "New skill: Lower My Bill 💸",

--- a/web/newsletters/v71.0.0.html
+++ b/web/newsletters/v71.0.0.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>9 new skills: get your money back 💷</title></head>
+<body style="margin:0;padding:0;background:#f4f1ee;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;-webkit-font-smoothing:antialiased;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f4f1ee;padding:24px 12px;">
+<tr><td align="center">
+  <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;background:#ffffff;border-radius:16px;overflow:hidden;box-shadow:0 2px 12px rgba(0,0,0,.06);">
+    <!-- header -->
+    <tr><td style="background:linear-gradient(135deg,#d9605a,#b94a45);padding:28px 32px;">
+      <div style="font-size:20px;font-weight:800;color:#fff;letter-spacing:.2px;">📬 PM&nbsp;Skills</div>
+      <div style="font-size:13px;color:rgba(255,255,255,.9);margin-top:2px;">858 professional Agent Skills for your AI</div>
+    </td></tr>
+    <!-- hero -->
+    <tr><td style="padding:32px 32px 8px;">
+      <div style="display:inline-block;background:#fbeae8;color:#b94a45;font-size:12px;font-weight:700;padding:5px 12px;border-radius:999px;text-transform:uppercase;letter-spacing:.5px;">New release · v71.0.0</div>
+      <h1 style="margin:14px 0 4px;font-size:26px;line-height:1.25;color:#1a1a1a;">9 new skills: get your money back 💷</h1>
+    </td></tr>
+    <!-- body -->
+    <tr><td style="padding:8px 32px 4px;">
+      <p style="margin:10px 0;color:#333;line-height:1.6;font-size:15px;"><strong>Nine new skills this release — a "fight for your money" set plus the life-admin jobs everyone dreads.</strong></p>
+<h2 style="margin:22px 0 8px;font-size:18px;line-height:1.3;color:#1a1a1a;">💷 Get your money back</h2>
+<ul style="margin:8px 0 8px 0;padding-left:20px;">
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>warranty-claim</strong> — it broke just inside (or just outside) warranty; get the claim written, the proof to attach, and the consumer-law backstop for the brush-offs.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>price-match-request</strong> — found it cheaper, or the price dropped days after you bought? Claim the difference, with the exact evidence that qualifies.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>flight-delay-compensation</strong> — delayed, cancelled, or bumped? Find out if you are likely owed compensation (EU261 / UK / DOT-style) and send the claim.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>insurance-claim-appeal</strong> — a denial is often a first offer, not a verdict. Decode the reason, find the strongest grounds, and draft the appeal.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>late-invoice-chaser</strong> — freelancers: a warm→firm→formal sequence that gets an overdue invoice paid without torching the client.</li>
+</ul>
+<h2 style="margin:22px 0 8px;font-size:18px;line-height:1.3;color:#1a1a1a;">🏠 Life admin, handled</h2>
+<ul style="margin:8px 0 8px 0;padding-left:20px;">
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>small-claims-prep</strong> — the demand letter that often settles it, the evidence pack, the filing checklist, and a calm hearing script.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>moving-house-checklist</strong> — a backward-planned countdown: utilities, address changes, deposit recovery, packing waves.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>neighbor-dispute-resolver</strong> — de-escalate first, keep a paper trail, and know the real escalation path.</li>
+<li style="margin:4px 0;color:#333;line-height:1.5;"><strong>product-recall-check</strong> — is your car, appliance, or car seat under a safety recall? Check the official sources and claim the free fix.</li>
+</ul>
+<h2 style="margin:22px 0 8px;font-size:18px;line-height:1.3;color:#1a1a1a;">🛰️ New: follow without email</h2>
+<p style="margin:10px 0;color:#333;line-height:1.6;font-size:15px;">Prefer no inbox? There is now an <strong>RSS/Atom feed</strong> of new skills and a <strong>public newsletter archive</strong> — subscribe in any reader, or read past issues at a permalink.</p>
+<p style="margin:10px 0;color:#333;line-height:1.6;font-size:15px;"><strong>Library: 858 skills across 105 bundles.</strong> MIT licensed. Try any free at https://mohitagw15856.github.io/pm-claude-skills/</p>
+    </td></tr>
+    <!-- CTAs -->
+    <tr><td style="padding:16px 32px 28px;">
+      <a href="https://mohitagw15856.github.io/pm-claude-skills/" style="display:inline-block;margin:6px 8px 6px 0;padding:12px 22px;border-radius:10px;font-weight:700;font-size:15px;text-decoration:none;background:#d9605a;color:#ffffff;">Explore the skills</a>
+      <a href="https://github.com/mohitagw15856/pm-claude-skills/releases/tag/v71.0.0" style="display:inline-block;margin:6px 8px 6px 0;padding:12px 22px;border-radius:10px;font-weight:700;font-size:15px;text-decoration:none;background:#ffffff;color:#d9605a;border:2px solid #d9605a;">Read the release</a>
+      <p style="margin:14px 0 0;font-size:13px;color:#888;">Or install into your AI tool: <code style="background:#f3f0ee;border-radius:4px;padding:1px 5px;">npx pm-claude-skills add</code></p>
+    </td></tr>
+    <!-- footer -->
+    <tr><td style="background:#faf8f6;padding:22px 32px;border-top:1px solid #f0ece9;">
+      <p style="margin:0 0 6px;font-size:13px;color:#999;">You're getting this because you subscribed for new-skill announcements at <a href="https://mohitagw15856.github.io/pm-claude-skills/" style="color:#d9605a;">PM Skills</a>.</p>
+      <p style="margin:0;font-size:13px;color:#999;"><a href="https://github.com/mohitagw15856/pm-claude-skills/releases/tag/v71.0.0" style="color:#999;">Full release notes</a> · <a href="https://github.com/mohitagw15856/pm-claude-skills" style="color:#999;">GitHub</a> · <a href="{{ unsubscribe_url }}" style="color:#999;">Unsubscribe</a></p>
+    </td></tr>
+  </table>
+  <div style="font-size:12px;color:#bbb;margin-top:14px;">MIT licensed · Made with care</div>
+</td></tr>
+</table>
+</body></html>


### PR DESCRIPTION
## What does this PR add or change?

Prepares the **v71.0.0** release: version bump everywhere, the v71 announcement newsletter (in-repo + public archive), and a small website refresh. No skill files change (the 9 new skills already merged in #220) — this is the release bookkeeping around them.

---

## Type of change

- [x] Marketplace / plugin config change (version bump)
- [x] Documentation / assets (newsletter, site copy, featured skills)

---

## Details

**Version bump 70.0.0 → 71.0.0** (a new-skills wave = major bump):
- `package.json`, `.claude-plugin/marketplace.json`, `server.json` (top-level + `packages[0].version`)
- `python/pyproject.toml` 0.36.0 → 0.37.0 (independent minor)

**Newsletter:**
- `newsletters/v71.0.0.html` + `.md` — the announcement email, generated from the release notes, featuring the 9 new skills grouped as "get your money back" + life-admin, plus the new RSS/archive.
- Published to the public archive (`web/newsletters/` + `index.html`/`index.json`), so it has a permalink.

**Site refresh:**
- Pre-JS skill-count fallback `800+` → `850+` on the home page (the live count stays dynamic from `skills.json`).
- Catalogue search hint refreshed (`…lease, warranty, flight delay…`).
- Featured **Lower My Bill** and **Warranty Claim** on the home page to showcase the money theme.

**Banner/logo:** `hero.svg` already reflects **858** from the prior wave, so the README banner is current. (The social-preview PNGs render via a headless browser that isn't available in this environment — noted as a minor follow-up.)

## Checks

`npm run check` passes clean — 858 skills; SkillCheck, drift, 12-platform exports, workflows, exports-lint, i18n parity, and registry all green; no generated-file drift.

## After merge

Cut the tag: **`v71.0.0` → target `main`**, paste the release notes → publishing fires `newsletter-on-release.yml`, which rebuilds the same email as an artifact + job summary for one-click send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_