### PR TITLE
readme: invite organisations to sponsor a disclosed logo/link placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,10 @@ Add a skill via PR ([the standard](SKILL-AUTHORING-STANDARD.md), [CONTRIBUTING](
 
 If a skill saved you real money or a real mistake, **[star the repo](https://github.com/mohitagw15856/pm-claude-skills/stargazers)** — it's how others find it. Sponsors fund the playground's free runs and get [naming rights, not influence](docs/SPONSORSHIP.md): **[become a sponsor](https://github.com/sponsors/mohitagw15856)**.
 
+### 🏢 Sponsor the project
+
+Individuals sponsor via **[GitHub Sponsors](https://github.com/sponsors/mohitagw15856)**. **Organisations** interested in a sponsored logo + link: **[email me](mailto:mohit15856@gmail.com)** about a clearly-disclosed placement in this section — that's the whole arrangement: a logo and link only, never product integration or a product endorsement. I keep full editorial independence and may decline any sponsor whose product conflicts with users' interests.
+
 ## 📄 License
 
 MIT — use them, fork them, ship them at work. Skills are judgment, and judgment wants to be free.


### PR DESCRIPTION
## What does this PR add or change?

Adds a short **"🏢 Sponsor the project"** subheading to the existing `## ❤️ Support` section, inviting organisations to reach out by email about a sponsored logo + link — while making the vendor-neutral boundaries explicit.

---

## Type of change

- [x] Documentation update (README)

---

## The addition (one block, existing Support sentence untouched)

> ### 🏢 Sponsor the project
>
> Individuals sponsor via **[GitHub Sponsors](https://github.com/sponsors/mohitagw15856)**. **Organisations** interested in a sponsored logo + link: **[email me](mailto:mohit15856@gmail.com)** about a clearly-disclosed placement in this section — that's the whole arrangement: a logo and link only, never product integration or a product endorsement. I keep full editorial independence and may decline any sponsor whose product conflicts with users' interests.

## Why

- **Invites org sponsors by email** for logo/link placement.
- **Explicitly rules out** product integration and endorsement — keeping the library vendor-neutral and pre-empting "sponsorship = embed our API" expectations.
- **States editorial independence** and the right to decline conflicting sponsors.
- **More prominent** via a scannable subheading (appears in GitHub's auto-TOC) — but deliberately kept out of the emotional hero so it doesn't undercut it.

## Anything else the reviewer should know?

- Uses `mohit15856@gmail.com` as the contact — swap for a role alias (e.g. `sponsors@`) if preferred; one-line change.
- Docs-only; no skill-count or version impact. Drift clean (1153 skills / 130 bundles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8

---
_Generated by [Claude Code](https://claude.ai/code/session_018DwjNk3MthezheWLnasYe8)_