### PR TITLE
community: add YYLO Skills

### DIFF
--- a/COMMUNITY-SKILLS.md
+++ b/COMMUNITY-SKILLS.md
@@ -24,6 +24,7 @@ A directory of **skill repos and packs built by the community** that follow the
 | Skill / pack | Author | What it does | Repo |
 |---|---|---|---|
 | [Crew](https://github.com/Honorboxx/crew) | [@Honorboxx](https://github.com/Honorboxx) | Reviewer, debugger and planner agents plus scope/verify/git skills that size a task before coding and turn "done" into observed evidence. | https://github.com/Honorboxx/crew |
+| [YYLO Skills](https://github.com/yylo-dev/yylo-skills) | [@yylo-dev](https://github.com/yylo-dev) | Seven reusable agent skills for Claude Code, Codex, and Pi built around YYLO Ledger: task management, wiki and workflow Records, provenance-bound evidence, and validated task delivery. | https://github.com/yylo-dev/yylo-skills |
 
 <!-- COMMUNITY-SKILLS:ROWS-BELOW
   Add your row directly above this comment, keeping the four columns in order:


### PR DESCRIPTION
Adds one row to the community directory for **YYLO Skills** — a pack of seven agent skills (MIT) for Claude Code, Codex, and Pi.

- **Repo:** https://github.com/yylo-dev/yylo-skills
- **Contents:** 7 skills, each a standalone `skills/<slug>/SKILL.md` with valid frontmatter — `ledger-tasks-yylo` (Operate YYLO Ledger task management and source-of-truth boundaries), `wiki-yylo` (durable Markdown knowledge as revisioned Ledger Records), `workflow-yylo`, `artifact-yylo` (provenance-bound Ledger evidence), `understand-project-yylo`, `plan-ledger-tasks-yylo` (Create a PDR and implementation-sized Ledger tasks), `ralph-loop-yylo` (execute exactly one explicitly assigned Ledger task through validated delivery).
- **Install:** `npx skills add yylo-dev/yylo-skills`
- **Why:** the project-management skills (task management on a Kanban/Ledger board, implementation-sized planning, validated delivery) are the closest fit to this library's PM center, and this repo seemed like the natural discovery home for them.

Format self-check: `node scripts/check-community-skills.mjs` → `Community Skills check — OK (2 listed entries).` (+1/−0, row added directly above the ROWS-BELOW comment, alphabetical after Crew.)

**Disclosure:** I'm on the YYLO team (this is a self-submission of our own skill pack), and this PR was prepared with the help of an AI coding agent — happy to adjust the one-liner or drop the row if it doesn't fit.
